### PR TITLE
use dill if found

### DIFF
--- a/hickle.py
+++ b/hickle.py
@@ -275,7 +275,10 @@ def dump_dict(obj, h5f='', **kwargs):
 
 def no_match(obj, h5f, *args, **kwargs):
     """ If no match is made, raise an exception """
-    import cPickle
+    try:
+        import dill as cPickle
+    except:
+        import cPickle
 
     pickled_obj = cPickle.dumps(obj)
     h5f.create_dataset('type', data=['pickle'])
@@ -433,7 +436,10 @@ def load_pickle(h5f, safe=True):
   """
 
     if not safe:
-        import cPickle
+        try:
+            import dill as cPickle
+        except:
+            import cPickle
 
         data = h5f["data"][:]
         data = cPickle.loads(data[0])


### PR DESCRIPTION
Enable `hickle` to serialize most python objects seamlessly in the hdf files.  Probably better if one could pick the serializer at runtime, but this was easy.  No new dependency created, since it only uses `dill` if it's been installed.
```
>>> import hickle
>>> 
>>> f = open('foo.hkl', 'w')
>>> hickle.dump(lambda x:x, f)
dumping <type 'function'> to file <HDF5 file "foo.hkl" (mode r+)>
Warning: <type 'function'> type not understood, data have been serialized
>>> f.close()
>>> f = open('foo.hkl', 'r')
>>> g = hickle.load(f, safe=False)
>>> g(4)
4
```