### PR TITLE
Pickle fallback fixes

### DIFF
--- a/hickle/hickle.py
+++ b/hickle/hickle.py
@@ -376,9 +376,12 @@ def no_match(py_obj, h_group, call_id=0, **kwargs):
         h_group (h5.File.group): group to dump data into.
         call_id (int): index to identify object's relative location in the iterable.
     """
-    import cPickle
+    try:
+        import cPickle as pickle
+    except ModuleNotFoundError:
+        import pickle 
 
-    pickled_obj = cPickle.dumps(py_obj)
+    pickled_obj = pickle.dumps(py_obj)
     d = h_group.create_dataset('data_%i' % call_id, data=[pickled_obj])
     d.attrs["type"] = [b'pickle']
 

--- a/hickle/loaders/load_numpy.py
+++ b/hickle/loaders/load_numpy.py
@@ -142,6 +142,7 @@ hkl_types_dict = {
     b"np_dtype"            : load_np_dtype_dataset,
     b"np_scalar"           : load_np_scalar_dataset,
     b"ndarray"             : load_ndarray_dataset,
+    b"numpy.ndarray"       : load_ndarray_dataset,
     b"ndarray_masked_data" : load_ndarray_masked_dataset,
     b"ndarray_masked_mask" : load_nothing        # Loaded autormatically
 }

--- a/hickle/loaders/load_python3.py
+++ b/hickle/loaders/load_python3.py
@@ -102,6 +102,12 @@ def load_unicode_dataset(h_node):
 def load_none_dataset(h_node):
     return None
 
+def load_pickled_data(h_node):
+    py_type, data = get_type_and_data(h_node)
+    import pickle
+    return pickle.loads(data[0])
+
+
 def load_python_dtype_dataset(h_node):
     py_type, data = get_type_and_data(h_node)
     subtype = h_node.attrs["python_subdtype"]
@@ -138,6 +144,7 @@ hkl_types_dict = {
     b"bytes"           : load_bytes_dataset,
     b"python_dtype"   : load_python_dtype_dataset,
     b"string"         : load_string_dataset,
-    b"none"           : load_none_dataset
+    b"pickle"         : load_pickled_data,
+    b"none"           : load_none_dataset,
 }
 

--- a/hickle/loaders/load_python3.py
+++ b/hickle/loaders/load_python3.py
@@ -104,7 +104,10 @@ def load_none_dataset(h_node):
 
 def load_pickled_data(h_node):
     py_type, data = get_type_and_data(h_node)
-    import pickle
+    try:
+        import cPickle as pickle
+    except ModuleNotFoundError:
+        import pickle 
     return pickle.loads(data[0])
 
 

--- a/tests/test_hickle.py
+++ b/tests/test_hickle.py
@@ -90,8 +90,8 @@ def test_list():
     list_obj = [1, 2, 3, 4, 5]
     dump(list_obj, filename, mode)
     list_hkl = load(filename)
-    print(f'Initial list: {list_obj}')
-    print(f'Unhickled data: {list_hkl}')
+    #print(f'Initial list: {list_obj}')
+    #print(f'Unhickled data: {list_hkl}')
     try:
         assert type(list_obj) == type(list_hkl) == list
         assert list_obj == list_hkl


### PR DESCRIPTION
With these changes I've managed to properly dump and load a fairly large and complex object that pickle just could not handle(on 3.6).  I'm not sure if this branch is meant to stay compatible with py2, so importing old cPickle if it's available just in case.