### PR TITLE
make check_iterable_item_type work on more objects

### DIFF
--- a/hickle/helpers.py
+++ b/hickle/helpers.py
@@ -25,7 +25,7 @@ def sort_keys(key_list):
     key_list = list(key_list)
     #print(key_list)
 
-    to_int = lambda x: int(re.search('\d+', x).group(0))
+    to_int = lambda x: int(re.search(r'\d+', x).group(0))
     keys_by_int = sorted([(to_int(key), key) for key in key_list])
     return [ii[1] for ii in keys_by_int]
 
@@ -89,6 +89,8 @@ def check_iterable_item_type(iter_obj):
     try:
         first_type = type(next(iseq))
     except StopIteration:
+        return False
+    except Exception as ex:
         return False
 
     if isinstance(iter_obj, dict):


### PR DESCRIPTION
I have some funny objects that redefine `__getitem__` to make these work with `check_iterable_item_type` I have to add another `except`

(the actual type was `KeyError`, but to be safe I catch all exceptions)

@telegraphic 