### PR TITLE
Adding Windows Testing

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -55,8 +55,3 @@ test_script:
 
 on_success:
     - "coveralls"
-
-branches:
-  only:
-    - dev
-    - master

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,6 +43,7 @@ install:
 
     # Install testing requirements and hickle
     - "pip install -r requirements_test.txt"
+    - "pip install ."
 
 build: false
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,17 +41,10 @@ install:
     # Upgrade pip
     - "python -m pip install --user --upgrade pip setuptools wheel"
 
-    # Install testing requirements
-    - "pip install pytest coveralls"
-
-    # Install hickle
-    - "pip install -r requirements.txt"
-    - "pip install ."
+    # Install testing requirements and hickle
+    - "pip install -r requirements_test.txt"
 
 build: false
 
 test_script:
     - "python setup.py test"
-
-on_success:
-    - "coveralls"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,62 @@
+environment:
+    matrix:
+        - PYTHON: "C:\\Python27"
+          PYTHON_VERSION: "2.7.x"
+          PYTHON_ARCH: "32"
+
+        - PYTHON: "C:\\Python27-x64"
+          PYTHON_VERSION: "2.7.x"
+          PYTHON_ARCH: "64"
+
+        - PYTHON: "C:\\Python35"
+          PYTHON_VERSION: "3.5.x"
+          PYTHON_ARCH: "32"
+
+        - PYTHON: "C:\\Python35-x64"
+          PYTHON_VERSION: "3.5.x"
+          PYTHON_ARCH: "64"
+
+        - PYTHON: "C:\\Python36"
+          PYTHON_VERSION: "3.6.x"
+          PYTHON_ARCH: "32"
+
+        - PYTHON: "C:\\Python36-x64"
+          PYTHON_VERSION: "3.6.x"
+          PYTHON_ARCH: "64"
+
+        - PYTHON: "C:\\Python37"
+          PYTHON_VERSION: "3.7.x"
+          PYTHON_ARCH: "32"
+
+        - PYTHON: "C:\\Python37-x64"
+          PYTHON_VERSION: "3.7.x"
+          PYTHON_ARCH: "64"
+
+install:
+    # Prepend newly installed Python to the PATH of this build (this cannot be
+    # done from inside the powershell script as it would require to restart
+    # the parent CMD process).
+    - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
+    # Upgrade pip
+    - "python -m pip install --user --upgrade pip setuptools wheel"
+
+    # Install testing requirements
+    - "pip install pytest coveralls"
+
+    # Install hickle
+    - "pip install -r requirements.txt"
+    - "pip install ."
+
+build: false
+
+test_script:
+    - "python setup.py test"
+
+on_success:
+    - "coveralls"
+
+branches:
+  only:
+    - dev
+    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - sudo apt-get install -qq libhdf5-serial-dev
   - python -m pip install --upgrade pip setuptools wheel
   - pip install -r requirements_test.txt
+  - pip install .
 
 script:
   - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,3 @@ script:
 
 # Run code coverage
 after_success: coveralls
-
-# Run on dev and master branches
-branches:
-  only:
-    - dev
-    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,8 @@ python:
 install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libhdf5-serial-dev
-  - pip install pytest coveralls
-  - pip install -r requirements.txt
-  - pip install .
+  - python -m pip install --upgrade pip setuptools wheel
+  - pip install -r requirements_test.txt
 
 script:
   - python setup.py test

--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ For storing python dictionaries of lists, hickle beats the python json encoder, 
 
 It should be noted that these comparisons are of course not fair: storing in HDF5 will not help you convert something into JSON, nor will it help you serialize a string. But for quick storage of the contents of a python variable, it's a pretty good option.
 
-Installation guidelines (for Linux and Mac OS).
------------------------------------------------
+Installation guidelines
+-----------------------
 
 ### Easy method
 Install with `pip` by running `pip install hickle` from the command line.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -144,8 +144,8 @@ For storing python dictionaries of lists, hickle beats the python json encoder, 
 
 It should be noted that these comparisons are of course not fair: storing in HDF5 will not help you convert something into JSON, nor will it help you serialize a string. But for quick storage of the contents of a python variable, it's a pretty good option.
 
-Installation guidelines (for Linux and Mac OS).
------------------------------------------------
+Installation guidelines
+-----------------------
 
 ### Easy method
 Install with `pip` by running `pip install hickle` from the command line.

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,3 @@
-.
 pytest
 pytest-cov
 pytest-runner

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,9 @@
+.
+pytest
+pytest-cov
+pytest-runner
+astropy<3.1;python_version>="3"
+astropy<3.0;python_version=="2.7.*"
+scipy
+pandas
+coveralls

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ with open("README.md", "r") as fh:
 with open("requirements.txt", 'r') as fh:
     requirements = fh.read().splitlines()
 
+with open("requirements_test.txt", 'r') as fh:
+    test_requirements = fh.read().splitlines()
+
 setup(name='hickle',
       version=version,
       description='Hickle - a HDF5 based version of pickle',
@@ -31,6 +34,7 @@ setup(name='hickle',
       keywords=['pickle', 'hdf5', 'data storage', 'data export'],
       #py_modules = ['hickle', 'hickle_legacy'],
       install_requires=requirements,
+      tests_require=test_requirements,
 #      setup_requires = ['pytest-runner', 'pytest-cov'],
       python_requires='>=2.7',
       packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -9,16 +9,14 @@
 from setuptools import setup, find_packages
 import sys
 
-if sys.version_info.major == 3:
-      astro = "astropy<3.1"
-else:
-      astro = "astropy<3.0"
-
 version = '3.4.3'
 author  = 'Danny Price'
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
+
+with open("requirements.txt", 'r') as fh:
+    requirements = fh.read().splitlines()
 
 setup(name='hickle',
       version=version,
@@ -32,9 +30,8 @@ setup(name='hickle',
       platforms='Cross platform (Linux, Mac OSX, Windows)',
       keywords=['pickle', 'hdf5', 'data storage', 'data export'],
       #py_modules = ['hickle', 'hickle_legacy'],
-      install_requires=['numpy', 'h5py'],
-      setup_requires = ['pytest-runner', 'pytest-cov'],
-      tests_require = ['pytest', astro, 'scipy', 'pandas'],
+      install_requires=requirements,
+#      setup_requires = ['pytest-runner', 'pytest-cov'],
       python_requires='>=2.7',
       packages=find_packages(),
       zip_safe=False,


### PR DESCRIPTION
I have added Windows testing (#101) for all Python versions.
In order to make it work properly, you will have to register on AppVeyor and import `hickle` after accepting the PR.
Coveralls is not automatically compatible with AppVeyor (only with Travis CI and CircleCI), so allowing coverage to be sent from AppVeyor requires a bit of extra work (however, CodeCov does actually work with AppVeyor).

I have also made some changes to where the requirements are being stored.
Now, the normal requirements are all stored in `requirements.txt`, whereas the testing requirements are stored in `requirements_test.txt`.
These files are automatically read and formatted such that they can be given to the `setup()` function in the `setup.py` file.

I have also removed the limitation that tests are only carried out on the `master` and `dev` branches.
Tests should be carried out on all, as otherwise it is not possible to do testing on forks.

If you want, I can also add a form of regular expressions to single-source the versioning of the package (see my PRISM package, `dev` branch, for an example of that).