### PR TITLE
no copy when loading astropy

### DIFF
--- a/hickle/loaders/load_astropy.py
+++ b/hickle/loaders/load_astropy.py
@@ -147,7 +147,7 @@ def create_astropy_table(py_obj, h_group, call_id=0, **kwargs):
 def load_astropy_quantity_dataset(h_node):
     py_type, data = get_type_and_data(h_node)
     unit = h_node.attrs["unit"][0]
-    q = Quantity(data, unit)
+    q = Quantity(data, unit, copy=False)
     return q
 
 def load_astropy_time_dataset(h_node):

--- a/hickle/loaders/load_numpy.py
+++ b/hickle/loaders/load_numpy.py
@@ -139,7 +139,7 @@ hkl_types_dict = {
     b"ndarray"             : load_ndarray_dataset,
     b"numpy.ndarray"       : load_ndarray_dataset,
     b"ndarray_masked_data" : load_ndarray_masked_dataset,
-    b"ndarray_masked_mask" : load_nothing        # Loaded autormatically
+    b"ndarray_masked_mask" : load_nothing        # Loaded automatically
 }
 
 


### PR DESCRIPTION
This reduces memory usage by 1/2 when loading astropy quantity arrays. Currently it's loading the numpy array and then copying it to create the astropy quantity array