### PR TITLE
Tests for deployment and installation

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,11 +41,14 @@ install:
     # Upgrade pip
     - "python -m pip install --user --upgrade pip setuptools wheel"
 
-    # Install testing requirements and hickle
+    # Install testing requirements
     - "pip install -r requirements_test.txt"
-    - "pip install ."
 
 build: false
 
 test_script:
+    - "check-manifest"
+    - "python setup.py sdist bdist_wheel"
+    - "twine check dist/*"
+    - "pip install ."
     - "python setup.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,12 @@ install:
   - sudo apt-get install -qq libhdf5-serial-dev
   - python -m pip install --upgrade pip setuptools wheel
   - pip install -r requirements_test.txt
-  - pip install .
 
 script:
+  - check-manifest
+  - python setup.py sdist bdist_wheel
+  - twine check dist/*
+  - pip install .
   - python setup.py test
 
 # Run code coverage

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,15 @@
 include LICENSE
-include requirements.txt
-include requirements_test.txt
+include *.md
+include MANIFEST.in
+include requirements*.txt
+include tests
+recursive-include tests *
+
+exclude docs
+recursive-exclude docs *
+exclude *.yml
+exclude .nojekyll
+exclude .pylintrc
+exclude paper*
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,3 +6,4 @@ astropy<3.0;python_version=="2.7.*"
 scipy
 pandas
 coveralls
+check-manifest

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,3 +7,4 @@ scipy
 pandas
 coveralls
 check-manifest
+twine>=1.13.0


### PR DESCRIPTION
This PR adds tests for Travis CI and AppVeyor that automatically check if `hickle` can be properly packaged up, deployed and installed.
Also, I added some more files to the MANIFEST.in file to make sure that `hickle` is properly packaged up.