### PR TITLE
Hickle subclasses

### DIFF
--- a/hickle/helpers.py
+++ b/hickle/helpers.py
@@ -1,20 +1,26 @@
 import re
 import six
 
+try:
+    import dill as pickle
+except ImportError:
+    try:
+        import cPickle as pickle
+    except ImportError:
+        import pickle
+
 def get_type_and_data(h_node):
     """ Helper function to return the py_type and data block for a HDF node """
-    py_type = h_node.attrs['base_type']
+    py_type = pickle.loads(h_node.attrs['type'])
+    base_type = h_node.attrs['base_type']
     data = h_node[()]
-#    if h_node.shape == ():
-#        data = h_node.value
-#    else:
-#        data  = h_node[:]
-    return py_type, data
+    return py_type, base_type, data
 
 def get_type(h_node):
     """ Helper function to return the py_type for a HDF node """
-    py_type = h_node.attrs['base_type']
-    return py_type
+    py_type = pickle.loads(h_node.attrs['type'])
+    base_type = h_node.attrs['base_type']
+    return py_type, base_type
 
 def sort_keys(key_list):
     """ Take a list of strings and sort it by integer value within string

--- a/hickle/helpers.py
+++ b/hickle/helpers.py
@@ -3,7 +3,7 @@ import six
 
 def get_type_and_data(h_node):
     """ Helper function to return the py_type and data block for a HDF node """
-    py_type = h_node.attrs["type"]
+    py_type = h_node.attrs['base_type']
     data = h_node[()]
 #    if h_node.shape == ():
 #        data = h_node.value
@@ -13,7 +13,7 @@ def get_type_and_data(h_node):
 
 def get_type(h_node):
     """ Helper function to return the py_type for a HDF node """
-    py_type = h_node.attrs["type"]
+    py_type = h_node.attrs['base_type']
     return py_type
 
 def sort_keys(key_list):

--- a/hickle/helpers.py
+++ b/hickle/helpers.py
@@ -3,7 +3,7 @@ import six
 
 def get_type_and_data(h_node):
     """ Helper function to return the py_type and data block for a HDF node """
-    py_type = h_node.attrs["type"][0]
+    py_type = h_node.attrs["type"]
     data = h_node[()]
 #    if h_node.shape == ():
 #        data = h_node.value
@@ -13,7 +13,7 @@ def get_type_and_data(h_node):
 
 def get_type(h_node):
     """ Helper function to return the py_type for a HDF node """
-    py_type = h_node.attrs["type"][0]
+    py_type = h_node.attrs["type"]
     return py_type
 
 def sort_keys(key_list):

--- a/hickle/hickle.py
+++ b/hickle/hickle.py
@@ -319,12 +319,22 @@ def create_dataset_lookup(py_obj):
         match: function that should be used to dump data to a new dataset
     """
 
-    t = type(py_obj)
+    # Obtain the MRO of this object
+    mro_list = py_obj.__class__.mro()
 
-    match = types_dict.get(t, no_match)
+    # Create a match_map
+    match_map = map(types_dict.get, mro_list)
 
-    return match
+    # Loop over the entire match_map until something else than None is found
+    for match in match_map:
+        if match is not None:
+            break
+    # If that did not happen, then match is no_match
+    else:
+        match = no_match
 
+    # Return found match
+    return(match)
 
 
 def create_hkl_dataset(py_obj, h_group, call_id=0, **kwargs):

--- a/hickle/hickle.py
+++ b/hickle/hickle.py
@@ -278,7 +278,7 @@ def dump(py_obj, file_obj, mode='w', track_times=True, path='/', **kwargs):
         h5f, close_flag = file_opener(file_obj, mode, track_times)
         h5f.attrs["CLASS"] = b'hickle'
         h5f.attrs["VERSION"] = get_distribution('hickle').version
-        h5f.attrs["type"] = b'hickle'
+        h5f.attrs['base_type'] = b'hickle'
         # Log which version of python was used to generate the hickle file
         pv = sys.version_info
         py_ver = "%i.%i.%i" % (pv[0], pv[1], pv[2])
@@ -288,7 +288,7 @@ def dump(py_obj, file_obj, mode='w', track_times=True, path='/', **kwargs):
 
         if h_root_group is None:
             h_root_group = h5f.create_group(path)
-            h_root_group.attrs["type"] = b'hickle'
+            h_root_group.attrs['base_type'] = b'hickle'
 
         _dump(py_obj, h_root_group, **kwargs)
     except NoMatchError:
@@ -362,7 +362,7 @@ def create_hkl_group(py_obj, h_group, call_id=0):
 
     """
     h_subgroup = h_group.create_group('data_%i' % call_id)
-    h_subgroup.attrs['type'] = str(type(py_obj)).encode('ascii', 'ignore')
+    h_subgroup.attrs['base_type'] = str(type(py_obj)).encode('ascii', 'ignore')
     return h_subgroup
 
 
@@ -381,14 +381,14 @@ def create_dict_dataset(py_obj, h_group, call_id=0, **kwargs):
         call_id (int): index to identify object's relative location in the iterable.
     """
     h_dictgroup = h_group.create_group('data_%i' % call_id)
-    h_dictgroup.attrs['type'] = str(type(py_obj)).encode('ascii', 'ignore')
+    h_dictgroup.attrs['base_type'] = str(type(py_obj)).encode('ascii', 'ignore')
 
     for key, py_subobj in py_obj.items():
         if isinstance(key, string_types):
             h_subgroup = h_dictgroup.create_group("%r" % (key))
         else:
             h_subgroup = h_dictgroup.create_group(str(key))
-        h_subgroup.attrs["type"] = b'dict_item'
+        h_subgroup.attrs['base_type'] = b'dict_item'
 
         h_subgroup.attrs["key_type"] = str(type(key)).encode('ascii', 'ignore')
 
@@ -408,7 +408,7 @@ def no_match(py_obj, h_group, call_id=0, **kwargs):
     """
     pickled_obj = pickle.dumps(py_obj)
     d = h_group.create_dataset('data_%i' % call_id, data=[pickled_obj])
-    d.attrs["type"] = b'pickle'
+    d.attrs['base_type'] = b'pickle'
 
     warnings.warn("%s type not understood, data have been serialized" % type(py_obj),
                   SerializedWarning)
@@ -593,7 +593,7 @@ def _load(py_container, h_group):
 
         py_subcontainer = PyContainer()
         try:
-            py_subcontainer.container_type = bytes(h_group.attrs['type'])
+            py_subcontainer.container_type = bytes(h_group.attrs['base_type'])
         except KeyError:
             raise
             #py_subcontainer.container_type = ''

--- a/hickle/hickle.py
+++ b/hickle/hickle.py
@@ -459,6 +459,7 @@ class PyContainer(list):
         self.container_base_type = None
         self.name = None
         self.key_type = None
+        self.base_key_type = None
 
     def convert(self):
         """ Convert from PyContainer to python core data type.
@@ -648,9 +649,6 @@ def _load(py_container, h_group):
             raise
 
         py_subcontainer.name = h_group.name
-
-#        if py_subcontainer.container_base_type == b"<class 'dict'>":
-#            py_subcontainer.container_type = pickle.loads(h_group.attrs['type'])
 
         if py_subcontainer.container_base_type == b'dict_item':
             py_subcontainer.base_key_type = h_group.attrs['base_key_type']

--- a/hickle/hickle.py
+++ b/hickle/hickle.py
@@ -365,7 +365,7 @@ def create_hkl_group(py_obj, h_group, call_id=0):
 
     """
     h_subgroup = h_group.create_group('data_%i' % call_id)
-    h_subgroup.attrs['base_type'] = str(type(py_obj)).encode('ascii', 'ignore')
+    h_subgroup.attrs['base_type'] = create_dataset_lookup(py_obj)[1]
     return h_subgroup
 
 

--- a/hickle/hickle.py
+++ b/hickle/hickle.py
@@ -278,7 +278,7 @@ def dump(py_obj, file_obj, mode='w', track_times=True, path='/', **kwargs):
         h5f, close_flag = file_opener(file_obj, mode, track_times)
         h5f.attrs["CLASS"] = b'hickle'
         h5f.attrs["VERSION"] = get_distribution('hickle').version
-        h5f.attrs["type"] = [b'hickle']
+        h5f.attrs["type"] = b'hickle'
         # Log which version of python was used to generate the hickle file
         pv = sys.version_info
         py_ver = "%i.%i.%i" % (pv[0], pv[1], pv[2])
@@ -288,7 +288,7 @@ def dump(py_obj, file_obj, mode='w', track_times=True, path='/', **kwargs):
 
         if h_root_group is None:
             h_root_group = h5f.create_group(path)
-            h_root_group.attrs["type"] = [b'hickle']
+            h_root_group.attrs["type"] = b'hickle'
 
         _dump(py_obj, h_root_group, **kwargs)
     except NoMatchError:
@@ -362,7 +362,7 @@ def create_hkl_group(py_obj, h_group, call_id=0):
 
     """
     h_subgroup = h_group.create_group('data_%i' % call_id)
-    h_subgroup.attrs['type'] = [str(type(py_obj)).encode('ascii', 'ignore')]
+    h_subgroup.attrs['type'] = str(type(py_obj)).encode('ascii', 'ignore')
     return h_subgroup
 
 
@@ -381,16 +381,16 @@ def create_dict_dataset(py_obj, h_group, call_id=0, **kwargs):
         call_id (int): index to identify object's relative location in the iterable.
     """
     h_dictgroup = h_group.create_group('data_%i' % call_id)
-    h_dictgroup.attrs['type'] = [str(type(py_obj)).encode('ascii', 'ignore')]
+    h_dictgroup.attrs['type'] = str(type(py_obj)).encode('ascii', 'ignore')
 
     for key, py_subobj in py_obj.items():
         if isinstance(key, string_types):
             h_subgroup = h_dictgroup.create_group("%r" % (key))
         else:
             h_subgroup = h_dictgroup.create_group(str(key))
-        h_subgroup.attrs["type"] = [b'dict_item']
+        h_subgroup.attrs["type"] = b'dict_item'
 
-        h_subgroup.attrs["key_type"] = [str(type(key)).encode('ascii', 'ignore')]
+        h_subgroup.attrs["key_type"] = str(type(key)).encode('ascii', 'ignore')
 
         _dump(py_subobj, h_subgroup, call_id=0, **kwargs)
 
@@ -408,7 +408,7 @@ def no_match(py_obj, h_group, call_id=0, **kwargs):
     """
     pickled_obj = pickle.dumps(py_obj)
     d = h_group.create_dataset('data_%i' % call_id, data=[pickled_obj])
-    d.attrs["type"] = [b'pickle']
+    d.attrs["type"] = b'pickle'
 
     warnings.warn("%s type not understood, data have been serialized" % type(py_obj),
                   SerializedWarning)
@@ -447,7 +447,7 @@ class PyContainer(list):
             keys = []
             for item in self:
                 key = item.name.split('/')[-1]
-                key_type = item.key_type[0]
+                key_type = item.key_type
                 if key_type in container_key_types_dict.keys():
                     to_type_fn = container_key_types_dict[key_type]
                     key = to_type_fn(key)
@@ -593,7 +593,7 @@ def _load(py_container, h_group):
 
         py_subcontainer = PyContainer()
         try:
-            py_subcontainer.container_type = bytes(h_group.attrs['type'][0])
+            py_subcontainer.container_type = bytes(h_group.attrs['type'])
         except KeyError:
             raise
             #py_subcontainer.container_type = ''

--- a/hickle/hickle.py
+++ b/hickle/hickle.py
@@ -354,6 +354,7 @@ def create_hkl_dataset(py_obj, h_group, call_id=0, **kwargs):
 
     # do the creation
     create_dataset(py_obj, base_type, h_group, call_id, **kwargs)
+    h_group['data_%i' % (call_id)].attrs['type'] = np.array(pickle.dumps(py_obj.__class__))
 
 
 def create_hkl_group(py_obj, h_group, call_id=0):
@@ -365,6 +366,7 @@ def create_hkl_group(py_obj, h_group, call_id=0):
 
     """
     h_subgroup = h_group.create_group('data_%i' % call_id)
+    h_subgroup.attrs['type'] = np.array(pickle.dumps(py_obj.__class__))
     h_subgroup.attrs['base_type'] = create_dataset_lookup(py_obj)[1]
     return h_subgroup
 

--- a/hickle/hickle.py
+++ b/hickle/hickle.py
@@ -34,8 +34,7 @@ import h5py as h5
 
 from .helpers import get_type, sort_keys, check_is_iterable, check_iterable_item_type
 from .lookup import types_dict, hkl_types_dict, types_not_to_sort, \
-    container_types_dict, container_key_types_dict
-from .lookup import check_is_ndarray_like
+    container_types_dict, container_key_types_dict, check_is_ndarray_like
 
 
 try:
@@ -46,10 +45,6 @@ except ImportError:
 
 from six import PY2, PY3, string_types, integer_types
 import io
-
-# Make several aliases for Python2/Python3 compatibility
-if PY3:
-    file = io.TextIOWrapper
 
 # Import a default 'pickler'
 # Not the nicest import code, but should work on Py2/Py3
@@ -62,6 +57,10 @@ except ImportError:
         import pickle
 
 import warnings
+
+# Make several aliases for Python2/Python3 compatibility
+if PY3:
+    file = io.TextIOWrapper
 
 try:
     __version__ = get_distribution('hickle').version
@@ -319,11 +318,10 @@ def create_dataset_lookup(py_obj):
     Returns:
         match: function that should be used to dump data to a new dataset
     """
-    t = type(py_obj)
-    types_lookup = {dict: create_dict_dataset}
-    types_lookup.update(types_dict)
 
-    match = types_lookup.get(t, no_match)
+    t = type(py_obj)
+
+    match = types_dict.get(t, no_match)
 
     return match
 
@@ -385,6 +383,9 @@ def create_dict_dataset(py_obj, h_group, call_id=0, **kwargs):
         h_subgroup.attrs["key_type"] = [str(type(key)).encode('ascii', 'ignore')]
 
         _dump(py_subobj, h_subgroup, call_id=0, **kwargs)
+
+# Add create_dict_dataset to types_dict
+types_dict[dict] = create_dict_dataset
 
 
 def no_match(py_obj, h_group, call_id=0, **kwargs):

--- a/hickle/hickle.py
+++ b/hickle/hickle.py
@@ -323,14 +323,13 @@ def create_dataset_lookup(py_obj):
     # Obtain the MRO of this object
     mro_list = py_obj.__class__.mro()
 
-    # Create a match_map
-    match_map = map(types_dict.get, mro_list)
+    # Create a type_map
+    type_map = map(types_dict.get, mro_list)
 
-    # Loop over the entire match_map until something else than None is found
-    for i, match in enumerate(match_map):
-        if match is not None:
-            match = match[0]
-            base_type = str(mro_list[i])
+    # Loop over the entire type_map until something else than None is found
+    for i, type_item in enumerate(type_map):
+        if type_item is not None:
+            match, base_type = type_item
             break
     # If that did not happen, then match is no_match
     else:
@@ -354,7 +353,7 @@ def create_hkl_dataset(py_obj, h_group, call_id=0, **kwargs):
     create_dataset, base_type = create_dataset_lookup(py_obj)
 
     # do the creation
-    create_dataset(py_obj, h_group, call_id, **kwargs)
+    create_dataset(py_obj, base_type, h_group, call_id, **kwargs)
 
 
 def create_hkl_group(py_obj, h_group, call_id=0):
@@ -370,7 +369,7 @@ def create_hkl_group(py_obj, h_group, call_id=0):
     return h_subgroup
 
 
-def create_dict_dataset(py_obj, h_group, call_id=0, **kwargs):
+def create_dict_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
     """ Creates a data group for each key in dictionary
 
     Notes:

--- a/hickle/loaders/load_astropy.py
+++ b/hickle/loaders/load_astropy.py
@@ -145,13 +145,13 @@ def create_astropy_table(py_obj, base_type, h_group, call_id=0, **kwargs):
 
 
 def load_astropy_quantity_dataset(h_node):
-    py_type, data = get_type_and_data(h_node)
+    _, _, data = get_type_and_data(h_node)
     unit = h_node.attrs["unit"]
     q = Quantity(data, unit, copy=False)
     return q
 
 def load_astropy_time_dataset(h_node):
-    py_type, data = get_type_and_data(h_node)
+    _, _, data = get_type_and_data(h_node)
     if six.PY3:
         fmt = h_node.attrs["format"].decode('ascii')
         scale = h_node.attrs["scale"].decode('ascii')
@@ -162,20 +162,20 @@ def load_astropy_time_dataset(h_node):
     return q
 
 def load_astropy_angle_dataset(h_node):
-    py_type, data = get_type_and_data(h_node)
+    _, _, data = get_type_and_data(h_node)
     unit = h_node.attrs["unit"]
     q = Angle(data, unit)
     return q
 
 def load_astropy_skycoord_dataset(h_node):
-    py_type, data = get_type_and_data(h_node)
+    _, _, data = get_type_and_data(h_node)
     lon_unit = h_node.attrs["lon_unit"]
     lat_unit = h_node.attrs["lat_unit"]
     q = SkyCoord(data[:,0], data[:, 1], unit=(lon_unit, lat_unit))
     return q
 
 def load_astropy_constant_dataset(h_node):
-    py_type, data = get_type_and_data(h_node)
+    _, _, data = get_type_and_data(h_node)
     unit   = h_node.attrs["unit"]
     abbrev = h_node.attrs["abbrev"]
     name   = h_node.attrs["name"]
@@ -190,7 +190,7 @@ def load_astropy_constant_dataset(h_node):
     return c
 
 def load_astropy_table(h_node):
-    py_type, data = get_type_and_data(h_node)
+    _, _, data = get_type_and_data(h_node)
     metadata = dict(h_node.attrs.items())
     metadata.pop('type')
     metadata.pop('base_type')

--- a/hickle/loaders/load_astropy.py
+++ b/hickle/loaders/load_astropy.py
@@ -19,7 +19,7 @@ def create_astropy_quantity(py_obj, h_group, call_id=0, **kwargs):
     # kwarg compression etc does not work on scalars
     d = h_group.create_dataset('data_%i' % call_id, data=py_obj.value,
                                dtype='float64')     #, **kwargs)
-    d.attrs["type"] = b'astropy_quantity'
+    d.attrs['base_type'] = b'astropy_quantity'
     if six.PY3:
         unit = bytes(str(py_obj.unit), 'ascii')
     else:
@@ -37,7 +37,7 @@ def create_astropy_angle(py_obj, h_group, call_id=0, **kwargs):
     # kwarg compression etc does not work on scalars
     d = h_group.create_dataset('data_%i' % call_id, data=py_obj.value,
                                dtype='float64')     #, **kwargs)
-    d.attrs["type"] = b'astropy_angle'
+    d.attrs['base_type'] = b'astropy_angle'
     if six.PY3:
         unit = str(py_obj.unit).encode('ascii')
     else:
@@ -59,7 +59,7 @@ def create_astropy_skycoord(py_obj, h_group, call_id=0, **kwargs):
 
     d = h_group.create_dataset('data_%i' % call_id, data=dd,
                                dtype='float64')     #, **kwargs)
-    d.attrs["type"] = b'astropy_skycoord'
+    d.attrs['base_type'] = b'astropy_skycoord'
     if six.PY3:
         lon_unit = str(py_obj.data.lon.unit).encode('ascii')
         lat_unit = str(py_obj.data.lat.unit).encode('ascii')
@@ -91,7 +91,7 @@ def create_astropy_time(py_obj, h_group, call_id=0, **kwargs):
             data.append(str(item).encode('ascii'))
 
     d = h_group.create_dataset('data_%i' % call_id, data=data, dtype=dtype)     #, **kwargs)
-    d.attrs["type"] = b'astropy_time'
+    d.attrs['base_type'] = b'astropy_time'
     if six.PY2:
         fmt   = str(py_obj.format)
         scale = str(py_obj.scale)
@@ -112,7 +112,7 @@ def create_astropy_constant(py_obj, h_group, call_id=0, **kwargs):
     # kwarg compression etc does not work on scalars
     d = h_group.create_dataset('data_%i' % call_id, data=py_obj.value,
                                dtype='float64')     #, **kwargs)
-    d.attrs["type"]   = b'astropy_constant'
+    d.attrs['base_type']   = b'astropy_constant'
     d.attrs["unit"]   = str(py_obj.unit)
     d.attrs["abbrev"] = str(py_obj.abbrev)
     d.attrs["name"]   = str(py_obj.name)
@@ -133,7 +133,7 @@ def create_astropy_table(py_obj, h_group, call_id=0, **kwargs):
     """
     data = py_obj.as_array()
     d = h_group.create_dataset('data_%i' % call_id, data=data, dtype=data.dtype, **kwargs)
-    d.attrs['type']  = b'astropy_table'
+    d.attrs['base_type']  = b'astropy_table'
 
     if six.PY3:
         colnames = [bytes(cn, 'ascii') for cn in py_obj.colnames]
@@ -192,7 +192,7 @@ def load_astropy_constant_dataset(h_node):
 def load_astropy_table(h_node):
     py_type, data = get_type_and_data(h_node)
     metadata = dict(h_node.attrs.items())
-    metadata.pop('type')
+    metadata.pop('base_type')
     metadata.pop('colnames')
 
     if six.PY3:

--- a/hickle/loaders/load_astropy.py
+++ b/hickle/loaders/load_astropy.py
@@ -192,6 +192,7 @@ def load_astropy_constant_dataset(h_node):
 def load_astropy_table(h_node):
     py_type, data = get_type_and_data(h_node)
     metadata = dict(h_node.attrs.items())
+    metadata.pop('type')
     metadata.pop('base_type')
     metadata.pop('colnames')
 

--- a/hickle/loaders/load_astropy.py
+++ b/hickle/loaders/load_astropy.py
@@ -8,7 +8,7 @@ from astropy.time import Time
 from hickle.helpers import get_type_and_data
 import six
 
-def create_astropy_quantity(py_obj, base_type, h_group, call_id=0, **kwargs):
+def create_astropy_quantity(py_obj, h_group, name, **kwargs):
     """ dumps an astropy quantity
 
     Args:
@@ -17,16 +17,16 @@ def create_astropy_quantity(py_obj, base_type, h_group, call_id=0, **kwargs):
         call_id (int): index to identify object's relative location in the iterable.
     """
     # kwarg compression etc does not work on scalars
-    d = h_group.create_dataset('data_%i' % call_id, data=py_obj.value,
+    d = h_group.create_dataset(name, data=py_obj.value,
                                dtype='float64')     #, **kwargs)
-    d.attrs['base_type'] = b'astropy_quantity'
     if six.PY3:
         unit = bytes(str(py_obj.unit), 'ascii')
     else:
         unit = str(py_obj.unit)
     d.attrs['unit'] = unit
+    return(d)
 
-def create_astropy_angle(py_obj, base_type, h_group, call_id=0, **kwargs):
+def create_astropy_angle(py_obj, h_group, name, **kwargs):
     """ dumps an astropy quantity
 
     Args:
@@ -35,16 +35,16 @@ def create_astropy_angle(py_obj, base_type, h_group, call_id=0, **kwargs):
         call_id (int): index to identify object's relative location in the iterable.
     """
     # kwarg compression etc does not work on scalars
-    d = h_group.create_dataset('data_%i' % call_id, data=py_obj.value,
+    d = h_group.create_dataset(name, data=py_obj.value,
                                dtype='float64')     #, **kwargs)
-    d.attrs['base_type'] = b'astropy_angle'
     if six.PY3:
         unit = str(py_obj.unit).encode('ascii')
     else:
         unit = str(py_obj.unit)
     d.attrs['unit'] = unit
+    return(d)
 
-def create_astropy_skycoord(py_obj, base_type, h_group, call_id=0, **kwargs):
+def create_astropy_skycoord(py_obj, h_group, name, **kwargs):
     """ dumps an astropy quantity
 
     Args:
@@ -57,9 +57,8 @@ def create_astropy_skycoord(py_obj, base_type, h_group, call_id=0, **kwargs):
     lon = py_obj.data.lon.value
     dd = np.column_stack((lon, lat))
 
-    d = h_group.create_dataset('data_%i' % call_id, data=dd,
+    d = h_group.create_dataset(name, data=dd,
                                dtype='float64')     #, **kwargs)
-    d.attrs['base_type'] = b'astropy_skycoord'
     if six.PY3:
         lon_unit = str(py_obj.data.lon.unit).encode('ascii')
         lat_unit = str(py_obj.data.lat.unit).encode('ascii')
@@ -68,8 +67,9 @@ def create_astropy_skycoord(py_obj, base_type, h_group, call_id=0, **kwargs):
         lat_unit = str(py_obj.data.lat.unit)
     d.attrs['lon_unit'] = lon_unit
     d.attrs['lat_unit'] = lat_unit
+    return(d)
 
-def create_astropy_time(py_obj, base_type, h_group, call_id=0, **kwargs):
+def create_astropy_time(py_obj, h_group, name, **kwargs):
     """ dumps an astropy Time object
 
     Args:
@@ -90,8 +90,7 @@ def create_astropy_time(py_obj, base_type, h_group, call_id=0, **kwargs):
         for item in py_obj.value:
             data.append(str(item).encode('ascii'))
 
-    d = h_group.create_dataset('data_%i' % call_id, data=data, dtype=dtype)     #, **kwargs)
-    d.attrs['base_type'] = b'astropy_time'
+    d = h_group.create_dataset(name, data=data, dtype=dtype)     #, **kwargs)
     if six.PY2:
         fmt   = str(py_obj.format)
         scale = str(py_obj.scale)
@@ -101,7 +100,9 @@ def create_astropy_time(py_obj, base_type, h_group, call_id=0, **kwargs):
     d.attrs['format'] = fmt
     d.attrs['scale']  = scale
 
-def create_astropy_constant(py_obj, base_type, h_group, call_id=0, **kwargs):
+    return(d)
+
+def create_astropy_constant(py_obj, h_group, name, **kwargs):
     """ dumps an astropy constant
 
     Args:
@@ -110,9 +111,8 @@ def create_astropy_constant(py_obj, base_type, h_group, call_id=0, **kwargs):
         call_id (int): index to identify object's relative location in the iterable.
     """
     # kwarg compression etc does not work on scalars
-    d = h_group.create_dataset('data_%i' % call_id, data=py_obj.value,
+    d = h_group.create_dataset(name, data=py_obj.value,
                                dtype='float64')     #, **kwargs)
-    d.attrs['base_type']   = b'astropy_constant'
     d.attrs["unit"]   = str(py_obj.unit)
     d.attrs["abbrev"] = str(py_obj.abbrev)
     d.attrs["name"]   = str(py_obj.name)
@@ -121,9 +121,10 @@ def create_astropy_constant(py_obj, base_type, h_group, call_id=0, **kwargs):
 
     if py_obj.system:
         d.attrs["system"] = py_obj.system
+    return(d)
 
 
-def create_astropy_table(py_obj, base_type, h_group, call_id=0, **kwargs):
+def create_astropy_table(py_obj, h_group, name, **kwargs):
     """ Dump an astropy Table
 
     Args:
@@ -132,8 +133,7 @@ def create_astropy_table(py_obj, base_type, h_group, call_id=0, **kwargs):
         call_id (int): index to identify object's relative location in the iterable.
     """
     data = py_obj.as_array()
-    d = h_group.create_dataset('data_%i' % call_id, data=data, dtype=data.dtype, **kwargs)
-    d.attrs['base_type']  = b'astropy_table'
+    d = h_group.create_dataset(name, data=data, dtype=data.dtype, **kwargs)
 
     if six.PY3:
         colnames = [bytes(cn, 'ascii') for cn in py_obj.colnames]
@@ -142,6 +142,7 @@ def create_astropy_table(py_obj, base_type, h_group, call_id=0, **kwargs):
     d.attrs['colnames'] = colnames
     for key, value in py_obj.meta.items():
      d.attrs[key] = value
+    return(d)
 
 
 def load_astropy_quantity_dataset(h_node):

--- a/hickle/loaders/load_astropy.py
+++ b/hickle/loaders/load_astropy.py
@@ -19,12 +19,12 @@ def create_astropy_quantity(py_obj, h_group, call_id=0, **kwargs):
     # kwarg compression etc does not work on scalars
     d = h_group.create_dataset('data_%i' % call_id, data=py_obj.value,
                                dtype='float64')     #, **kwargs)
-    d.attrs["type"] = [b'astropy_quantity']
+    d.attrs["type"] = b'astropy_quantity'
     if six.PY3:
         unit = bytes(str(py_obj.unit), 'ascii')
     else:
         unit = str(py_obj.unit)
-    d.attrs['unit'] = [unit]
+    d.attrs['unit'] = unit
 
 def create_astropy_angle(py_obj, h_group, call_id=0, **kwargs):
     """ dumps an astropy quantity
@@ -37,12 +37,12 @@ def create_astropy_angle(py_obj, h_group, call_id=0, **kwargs):
     # kwarg compression etc does not work on scalars
     d = h_group.create_dataset('data_%i' % call_id, data=py_obj.value,
                                dtype='float64')     #, **kwargs)
-    d.attrs["type"] = [b'astropy_angle']
+    d.attrs["type"] = b'astropy_angle'
     if six.PY3:
         unit = str(py_obj.unit).encode('ascii')
     else:
         unit = str(py_obj.unit)
-    d.attrs['unit'] = [unit]
+    d.attrs['unit'] = unit
 
 def create_astropy_skycoord(py_obj, h_group, call_id=0, **kwargs):
     """ dumps an astropy quantity
@@ -59,15 +59,15 @@ def create_astropy_skycoord(py_obj, h_group, call_id=0, **kwargs):
 
     d = h_group.create_dataset('data_%i' % call_id, data=dd,
                                dtype='float64')     #, **kwargs)
-    d.attrs["type"] = [b'astropy_skycoord']
+    d.attrs["type"] = b'astropy_skycoord'
     if six.PY3:
         lon_unit = str(py_obj.data.lon.unit).encode('ascii')
         lat_unit = str(py_obj.data.lat.unit).encode('ascii')
     else:
         lon_unit = str(py_obj.data.lon.unit)
         lat_unit = str(py_obj.data.lat.unit)
-    d.attrs['lon_unit'] = [lon_unit]
-    d.attrs['lat_unit'] = [lat_unit]
+    d.attrs['lon_unit'] = lon_unit
+    d.attrs['lat_unit'] = lat_unit
 
 def create_astropy_time(py_obj, h_group, call_id=0, **kwargs):
     """ dumps an astropy Time object
@@ -91,15 +91,15 @@ def create_astropy_time(py_obj, h_group, call_id=0, **kwargs):
             data.append(str(item).encode('ascii'))
 
     d = h_group.create_dataset('data_%i' % call_id, data=data, dtype=dtype)     #, **kwargs)
-    d.attrs["type"] = [b'astropy_time']
+    d.attrs["type"] = b'astropy_time'
     if six.PY2:
         fmt   = str(py_obj.format)
         scale = str(py_obj.scale)
     else:
         fmt   = str(py_obj.format).encode('ascii')
         scale = str(py_obj.scale).encode('ascii')
-    d.attrs['format'] = [fmt]
-    d.attrs['scale']  = [scale]
+    d.attrs['format'] = fmt
+    d.attrs['scale']  = scale
 
 def create_astropy_constant(py_obj, h_group, call_id=0, **kwargs):
     """ dumps an astropy constant
@@ -112,15 +112,15 @@ def create_astropy_constant(py_obj, h_group, call_id=0, **kwargs):
     # kwarg compression etc does not work on scalars
     d = h_group.create_dataset('data_%i' % call_id, data=py_obj.value,
                                dtype='float64')     #, **kwargs)
-    d.attrs["type"]   = [b'astropy_constant']
-    d.attrs["unit"]   = [str(py_obj.unit)]
-    d.attrs["abbrev"] = [str(py_obj.abbrev)]
-    d.attrs["name"]   = [str(py_obj.name)]
-    d.attrs["reference"] = [str(py_obj.reference)]
-    d.attrs["uncertainty"] = [py_obj.uncertainty]
+    d.attrs["type"]   = b'astropy_constant'
+    d.attrs["unit"]   = str(py_obj.unit)
+    d.attrs["abbrev"] = str(py_obj.abbrev)
+    d.attrs["name"]   = str(py_obj.name)
+    d.attrs["reference"] = str(py_obj.reference)
+    d.attrs["uncertainty"] = py_obj.uncertainty
 
     if py_obj.system:
-        d.attrs["system"] = [py_obj.system]
+        d.attrs["system"] = py_obj.system
 
 
 def create_astropy_table(py_obj, h_group, call_id=0, **kwargs):
@@ -133,7 +133,7 @@ def create_astropy_table(py_obj, h_group, call_id=0, **kwargs):
     """
     data = py_obj.as_array()
     d = h_group.create_dataset('data_%i' % call_id, data=data, dtype=data.dtype, **kwargs)
-    d.attrs['type']  = [b'astropy_table']
+    d.attrs['type']  = b'astropy_table'
 
     if six.PY3:
         colnames = [bytes(cn, 'ascii') for cn in py_obj.colnames]
@@ -146,45 +146,45 @@ def create_astropy_table(py_obj, h_group, call_id=0, **kwargs):
 
 def load_astropy_quantity_dataset(h_node):
     py_type, data = get_type_and_data(h_node)
-    unit = h_node.attrs["unit"][0]
+    unit = h_node.attrs["unit"]
     q = Quantity(data, unit, copy=False)
     return q
 
 def load_astropy_time_dataset(h_node):
     py_type, data = get_type_and_data(h_node)
     if six.PY3:
-        fmt = h_node.attrs["format"][0].decode('ascii')
-        scale = h_node.attrs["scale"][0].decode('ascii')
+        fmt = h_node.attrs["format"].decode('ascii')
+        scale = h_node.attrs["scale"].decode('ascii')
     else:
-        fmt = h_node.attrs["format"][0]
-        scale = h_node.attrs["scale"][0]
+        fmt = h_node.attrs["format"]
+        scale = h_node.attrs["scale"]
     q = Time(data, format=fmt, scale=scale)
     return q
 
 def load_astropy_angle_dataset(h_node):
     py_type, data = get_type_and_data(h_node)
-    unit = h_node.attrs["unit"][0]
+    unit = h_node.attrs["unit"]
     q = Angle(data, unit)
     return q
 
 def load_astropy_skycoord_dataset(h_node):
     py_type, data = get_type_and_data(h_node)
-    lon_unit = h_node.attrs["lon_unit"][0]
-    lat_unit = h_node.attrs["lat_unit"][0]
+    lon_unit = h_node.attrs["lon_unit"]
+    lat_unit = h_node.attrs["lat_unit"]
     q = SkyCoord(data[:,0], data[:, 1], unit=(lon_unit, lat_unit))
     return q
 
 def load_astropy_constant_dataset(h_node):
     py_type, data = get_type_and_data(h_node)
-    unit   = h_node.attrs["unit"][0]
-    abbrev = h_node.attrs["abbrev"][0]
-    name   = h_node.attrs["name"][0]
-    ref    = h_node.attrs["reference"][0]
-    unc    = h_node.attrs["uncertainty"][0]
+    unit   = h_node.attrs["unit"]
+    abbrev = h_node.attrs["abbrev"]
+    name   = h_node.attrs["name"]
+    ref    = h_node.attrs["reference"]
+    unc    = h_node.attrs["uncertainty"]
 
     system = None
     if "system" in h_node.attrs.keys():
-        system = h_node.attrs["system"][0]
+        system = h_node.attrs["system"]
 
     c = Constant(abbrev, name, data, unit, unc, ref, system)
     return c

--- a/hickle/loaders/load_astropy.py
+++ b/hickle/loaders/load_astropy.py
@@ -8,7 +8,7 @@ from astropy.time import Time
 from hickle.helpers import get_type_and_data
 import six
 
-def create_astropy_quantity(py_obj, h_group, call_id=0, **kwargs):
+def create_astropy_quantity(py_obj, base_type, h_group, call_id=0, **kwargs):
     """ dumps an astropy quantity
 
     Args:
@@ -26,7 +26,7 @@ def create_astropy_quantity(py_obj, h_group, call_id=0, **kwargs):
         unit = str(py_obj.unit)
     d.attrs['unit'] = unit
 
-def create_astropy_angle(py_obj, h_group, call_id=0, **kwargs):
+def create_astropy_angle(py_obj, base_type, h_group, call_id=0, **kwargs):
     """ dumps an astropy quantity
 
     Args:
@@ -44,7 +44,7 @@ def create_astropy_angle(py_obj, h_group, call_id=0, **kwargs):
         unit = str(py_obj.unit)
     d.attrs['unit'] = unit
 
-def create_astropy_skycoord(py_obj, h_group, call_id=0, **kwargs):
+def create_astropy_skycoord(py_obj, base_type, h_group, call_id=0, **kwargs):
     """ dumps an astropy quantity
 
     Args:
@@ -69,7 +69,7 @@ def create_astropy_skycoord(py_obj, h_group, call_id=0, **kwargs):
     d.attrs['lon_unit'] = lon_unit
     d.attrs['lat_unit'] = lat_unit
 
-def create_astropy_time(py_obj, h_group, call_id=0, **kwargs):
+def create_astropy_time(py_obj, base_type, h_group, call_id=0, **kwargs):
     """ dumps an astropy Time object
 
     Args:
@@ -101,7 +101,7 @@ def create_astropy_time(py_obj, h_group, call_id=0, **kwargs):
     d.attrs['format'] = fmt
     d.attrs['scale']  = scale
 
-def create_astropy_constant(py_obj, h_group, call_id=0, **kwargs):
+def create_astropy_constant(py_obj, base_type, h_group, call_id=0, **kwargs):
     """ dumps an astropy constant
 
     Args:
@@ -123,7 +123,7 @@ def create_astropy_constant(py_obj, h_group, call_id=0, **kwargs):
         d.attrs["system"] = py_obj.system
 
 
-def create_astropy_table(py_obj, h_group, call_id=0, **kwargs):
+def create_astropy_table(py_obj, base_type, h_group, call_id=0, **kwargs):
     """ Dump an astropy Table
 
     Args:

--- a/hickle/loaders/load_numpy.py
+++ b/hickle/loaders/load_numpy.py
@@ -38,7 +38,7 @@ def create_np_scalar_dataset(py_obj, h_group, call_id=0, **kwargs):
 
     # DO NOT PASS KWARGS TO SCALAR DATASETS!
     d = h_group.create_dataset('data_%i' % call_id, data=py_obj)  # **kwargs)
-    d.attrs["type"] = [b'np_scalar']
+    d.attrs["type"] = b'np_scalar'
 
     if six.PY2:
         d.attrs["np_dtype"] = str(d.dtype)
@@ -55,7 +55,7 @@ def create_np_dtype(py_obj, h_group, call_id=0, **kwargs):
         call_id (int): index to identify object's relative location in the iterable.
     """
     d = h_group.create_dataset('data_%i' % call_id, data=[str(py_obj)])
-    d.attrs["type"] = [b'np_dtype']
+    d.attrs["type"] = b'np_dtype'
 
 
 def create_np_array_dataset(py_obj, h_group, call_id=0, **kwargs):
@@ -70,11 +70,11 @@ def create_np_array_dataset(py_obj, h_group, call_id=0, **kwargs):
         d = h_group.create_dataset('data_%i' % call_id, data=py_obj, **kwargs)
         #m = h_group.create_dataset('mask_%i' % call_id, data=py_obj.mask, **kwargs)
         m = h_group.create_dataset('data_%i_mask' % call_id, data=py_obj.mask, **kwargs)
-        d.attrs["type"] = [b'ndarray_masked_data']
-        m.attrs["type"] = [b'ndarray_masked_mask']
+        d.attrs["type"] = b'ndarray_masked_data'
+        m.attrs["type"] = b'ndarray_masked_mask'
     else:
         d = h_group.create_dataset('data_%i' % call_id, data=py_obj, **kwargs)
-        d.attrs["type"] = [b'ndarray']
+        d.attrs["type"] = b'ndarray'
 
 
 
@@ -104,13 +104,13 @@ types_dict = {
 
 def load_np_dtype_dataset(h_node):
     py_type, data = get_type_and_data(h_node)
-    data = np.dtype(data[0])
+    data = np.dtype(data)
     return data
 
 def load_np_scalar_dataset(h_node):
     py_type, data = get_type_and_data(h_node)
-    subtype = h_node.attrs["np_dtype"]
-    data = np.array([data], dtype=subtype)[0]
+    subtype = h_node.attrs["np_dtype"].decode('utf-8')
+    data = getattr(np, subtype)(data)
     return data
 
 def load_ndarray_dataset(h_node):

--- a/hickle/loaders/load_numpy.py
+++ b/hickle/loaders/load_numpy.py
@@ -27,7 +27,7 @@ def check_is_numpy_array(py_obj):
     return is_numpy
 
 
-def create_np_scalar_dataset(py_obj, h_group, call_id=0, **kwargs):
+def create_np_scalar_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
     """ dumps an np dtype object to h5py file
 
     Args:
@@ -46,7 +46,7 @@ def create_np_scalar_dataset(py_obj, h_group, call_id=0, **kwargs):
         d.attrs["np_dtype"] = bytes(str(d.dtype), 'ascii')
 
 
-def create_np_dtype(py_obj, h_group, call_id=0, **kwargs):
+def create_np_dtype(py_obj, base_type, h_group, call_id=0, **kwargs):
     """ dumps an np dtype object to h5py file
 
     Args:
@@ -58,7 +58,7 @@ def create_np_dtype(py_obj, h_group, call_id=0, **kwargs):
     d.attrs['base_type'] = b'np_dtype'
 
 
-def create_np_array_dataset(py_obj, h_group, call_id=0, **kwargs):
+def create_np_array_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
     """ dumps an ndarray object to h5py file
 
     Args:

--- a/hickle/loaders/load_numpy.py
+++ b/hickle/loaders/load_numpy.py
@@ -38,7 +38,7 @@ def create_np_scalar_dataset(py_obj, h_group, call_id=0, **kwargs):
 
     # DO NOT PASS KWARGS TO SCALAR DATASETS!
     d = h_group.create_dataset('data_%i' % call_id, data=py_obj)  # **kwargs)
-    d.attrs["type"] = b'np_scalar'
+    d.attrs['base_type'] = b'np_scalar'
 
     if six.PY2:
         d.attrs["np_dtype"] = str(d.dtype)
@@ -55,7 +55,7 @@ def create_np_dtype(py_obj, h_group, call_id=0, **kwargs):
         call_id (int): index to identify object's relative location in the iterable.
     """
     d = h_group.create_dataset('data_%i' % call_id, data=[str(py_obj)])
-    d.attrs["type"] = b'np_dtype'
+    d.attrs['base_type'] = b'np_dtype'
 
 
 def create_np_array_dataset(py_obj, h_group, call_id=0, **kwargs):
@@ -70,11 +70,11 @@ def create_np_array_dataset(py_obj, h_group, call_id=0, **kwargs):
         d = h_group.create_dataset('data_%i' % call_id, data=py_obj, **kwargs)
         #m = h_group.create_dataset('mask_%i' % call_id, data=py_obj.mask, **kwargs)
         m = h_group.create_dataset('data_%i_mask' % call_id, data=py_obj.mask, **kwargs)
-        d.attrs["type"] = b'ndarray_masked_data'
-        m.attrs["type"] = b'ndarray_masked_mask'
+        d.attrs['base_type'] = b'ndarray_masked_data'
+        m.attrs['base_type'] = b'ndarray_masked_mask'
     else:
         d = h_group.create_dataset('data_%i' % call_id, data=py_obj, **kwargs)
-        d.attrs["type"] = b'ndarray'
+        d.attrs['base_type'] = b'ndarray'
 
 
 

--- a/hickle/loaders/load_numpy.py
+++ b/hickle/loaders/load_numpy.py
@@ -34,7 +34,7 @@ def check_is_numpy_array(py_obj):
     return is_numpy
 
 
-def create_np_scalar_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
+def create_np_scalar_dataset(py_obj, h_group, name, **kwargs):
     """ dumps an np dtype object to h5py file
 
     Args:
@@ -44,16 +44,16 @@ def create_np_scalar_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
     """
 
     # DO NOT PASS KWARGS TO SCALAR DATASETS!
-    d = h_group.create_dataset('data_%i' % call_id, data=py_obj)  # **kwargs)
-    d.attrs['base_type'] = b'np_scalar'
+    d = h_group.create_dataset(name, data=py_obj)  # **kwargs)
 
     if six.PY2:
         d.attrs["np_dtype"] = str(d.dtype)
     else:
         d.attrs["np_dtype"] = bytes(str(d.dtype), 'ascii')
+    return(d)
 
 
-def create_np_dtype(py_obj, base_type, h_group, call_id=0, **kwargs):
+def create_np_dtype(py_obj, h_group, name, **kwargs):
     """ dumps an np dtype object to h5py file
 
     Args:
@@ -61,11 +61,11 @@ def create_np_dtype(py_obj, base_type, h_group, call_id=0, **kwargs):
         h_group (h5.File.group): group to dump data into.
         call_id (int): index to identify object's relative location in the iterable.
     """
-    d = h_group.create_dataset('data_%i' % call_id, data=[str(py_obj)])
-    d.attrs['base_type'] = b'np_dtype'
+    d = h_group.create_dataset(name, data=[str(py_obj)])
+    return(d)
 
 
-def create_np_array_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
+def create_np_array_dataset(py_obj, h_group, name, **kwargs):
     """ dumps an ndarray object to h5py file
 
     Args:
@@ -74,15 +74,14 @@ def create_np_array_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
         call_id (int): index to identify object's relative location in the iterable.
     """
     if isinstance(py_obj, np.ma.core.MaskedArray):
-        d = h_group.create_dataset('data_%i' % call_id, data=py_obj, **kwargs)
+        d = h_group.create_dataset(name, data=py_obj, **kwargs)
         #m = h_group.create_dataset('mask_%i' % call_id, data=py_obj.mask, **kwargs)
-        m = h_group.create_dataset('data_%i_mask' % call_id, data=py_obj.mask, **kwargs)
-        d.attrs['base_type'] = b'ndarray_masked_data'
+        m = h_group.create_dataset('%s_mask' % name, data=py_obj.mask, **kwargs)
         m.attrs['type'] = np.array(pickle.dumps(py_obj.mask.__class__))
         m.attrs['base_type'] = b'ndarray_masked_mask'
     else:
-        d = h_group.create_dataset('data_%i' % call_id, data=py_obj, **kwargs)
-        d.attrs['base_type'] = b'ndarray'
+        d = h_group.create_dataset(name, data=py_obj, **kwargs)
+    return(d)
 
 
 

--- a/hickle/loaders/load_numpy.py
+++ b/hickle/loaders/load_numpy.py
@@ -84,22 +84,22 @@ def create_np_array_dataset(py_obj, h_group, call_id=0, **kwargs):
 #######################
 
 types_dict = {
-    np.ndarray:  create_np_array_dataset,
-    np.ma.core.MaskedArray: create_np_array_dataset,
-    np.float16:    create_np_scalar_dataset,
-    np.float32:    create_np_scalar_dataset,
-    np.float64:    create_np_scalar_dataset,
-    np.int8:       create_np_scalar_dataset,
-    np.int16:      create_np_scalar_dataset,
-    np.int32:      create_np_scalar_dataset,
-    np.int64:      create_np_scalar_dataset,
-    np.uint8:      create_np_scalar_dataset,
-    np.uint16:     create_np_scalar_dataset,
-    np.uint32:     create_np_scalar_dataset,
-    np.uint64:     create_np_scalar_dataset,
-    np.complex64:  create_np_scalar_dataset,
-    np.complex128: create_np_scalar_dataset,
-    np.dtype:      create_np_dtype
+    np.ndarray:  (create_np_array_dataset, b'ndarray'),
+    np.ma.core.MaskedArray: (create_np_array_dataset, b"ndarray_masked_data"),
+    np.float16:    (create_np_scalar_dataset, b'np_scalar'),
+    np.float32:    (create_np_scalar_dataset, b'np_scalar'),
+    np.float64:    (create_np_scalar_dataset, b'np_scalar'),
+    np.int8:       (create_np_scalar_dataset, b'np_scalar'),
+    np.int16:      (create_np_scalar_dataset, b'np_scalar'),
+    np.int32:      (create_np_scalar_dataset, b'np_scalar'),
+    np.int64:      (create_np_scalar_dataset, b'np_scalar'),
+    np.uint8:      (create_np_scalar_dataset, b'np_scalar'),
+    np.uint16:     (create_np_scalar_dataset, b'np_scalar'),
+    np.uint32:     (create_np_scalar_dataset, b'np_scalar'),
+    np.uint64:     (create_np_scalar_dataset, b'np_scalar'),
+    np.complex64:  (create_np_scalar_dataset, b'np_scalar'),
+    np.complex128: (create_np_scalar_dataset, b'np_scalar'),
+    np.dtype:      (create_np_dtype, b'np_dtype')
 }
 
 def load_np_dtype_dataset(h_node):

--- a/hickle/loaders/load_python.py
+++ b/hickle/loaders/load_python.py
@@ -108,17 +108,17 @@ def load_python_dtype_dataset(h_node):
     return tcast(data)
 
 types_dict = {
-    list:        create_listlike_dataset,
-    tuple:       create_listlike_dataset,
-    set:         create_listlike_dataset,
-    str:         create_stringlike_dataset,
-    unicode:     create_stringlike_dataset,
-    int:         create_python_dtype_dataset,
-    float:       create_python_dtype_dataset,
-    long:        create_python_dtype_dataset,
-    bool:        create_python_dtype_dataset,
-    complex:     create_python_dtype_dataset,
-    NoneType:    create_none_dataset,
+    list:        (create_listlike_dataset, "<type 'list'>"),
+    tuple:       (create_listlike_dataset, "<type 'tuple'>"),
+    set:         (create_listlike_dataset, "<type 'set'>"),
+    str:         (create_stringlike_dataset, "string"),
+    unicode:     (create_stringlike_dataset, "unicode"),
+    int:         (create_python_dtype_dataset, "python_dtype"),
+    float:       (create_python_dtype_dataset, "python_dtype"),
+    long:        (create_python_dtype_dataset, "python_dtype"),
+    bool:        (create_python_dtype_dataset, "python_dtype"),
+    complex:     (create_python_dtype_dataset, "python_dtype"),
+    NoneType:    (create_none_dataset, "none"),
 }
 
 hkl_types_dict = {

--- a/hickle/loaders/load_python.py
+++ b/hickle/loaders/load_python.py
@@ -29,7 +29,7 @@ def create_listlike_dataset(py_obj, h_group, call_id=0, **kwargs):
     dtype = str(type(py_obj))
     obj = list(py_obj)
     d = h_group.create_dataset('data_%i' % call_id, data=obj, **kwargs)
-    d.attrs["type"] = dtype
+    d.attrs['base_type'] = dtype
 
 
 def create_python_dtype_dataset(py_obj, h_group, call_id=0, **kwargs):
@@ -43,7 +43,7 @@ def create_python_dtype_dataset(py_obj, h_group, call_id=0, **kwargs):
     # kwarg compression etc does not work on scalars
     d = h_group.create_dataset('data_%i' % call_id, data=py_obj,
                                dtype=type(py_obj))     #, **kwargs)
-    d.attrs["type"] = 'python_dtype'
+    d.attrs['base_type'] = 'python_dtype'
     d.attrs['python_subdtype'] = str(type(py_obj))
 
 
@@ -57,12 +57,12 @@ def create_stringlike_dataset(py_obj, h_group, call_id=0, **kwargs):
     """
     if isinstance(py_obj, str):
         d = h_group.create_dataset('data_%i' % call_id, data=[py_obj], **kwargs)
-        d.attrs["type"] = 'string'
+        d.attrs['base_type'] = 'string'
     else:
         dt = h5.special_dtype(vlen=unicode)
         dset = h_group.create_dataset('data_%i' % call_id, shape=(1, ), dtype=dt, **kwargs)
         dset[0] = py_obj
-        dset.attrs['type'] = 'unicode'
+        dset.attrs['base_type'] = 'unicode'
 
 
 def create_none_dataset(py_obj, h_group, call_id=0, **kwargs):
@@ -74,7 +74,7 @@ def create_none_dataset(py_obj, h_group, call_id=0, **kwargs):
         call_id (int): index to identify object's relative location in the iterable.
     """
     d = h_group.create_dataset('data_%i' % call_id, data=[0], **kwargs)
-    d.attrs["type"] = 'none'
+    d.attrs['base_type'] = 'none'
 
 
 def load_list_dataset(h_node):

--- a/hickle/loaders/load_python.py
+++ b/hickle/loaders/load_python.py
@@ -72,30 +72,30 @@ def create_none_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
 
 
 def load_list_dataset(h_node):
-    py_type, data = get_type_and_data(h_node)
+    _, _, data = get_type_and_data(h_node)
     return list(data)
 
 def load_tuple_dataset(h_node):
-    py_type, data = get_type_and_data(h_node)
+    _, _, data = get_type_and_data(h_node)
     return tuple(data)
 
 def load_set_dataset(h_node):
-    py_type, data = get_type_and_data(h_node)
+    _, _, data = get_type_and_data(h_node)
     return set(data)
 
 def load_string_dataset(h_node):
-    py_type, data = get_type_and_data(h_node)
+    _, _, data = get_type_and_data(h_node)
     return str(data)
 
 def load_unicode_dataset(h_node):
-    py_type, data = get_type_and_data(h_node)
+    _, _, data = get_type_and_data(h_node)
     return unicode(data)
 
 def load_none_dataset(h_node):
     return None
 
 def load_python_dtype_dataset(h_node):
-    py_type, data = get_type_and_data(h_node)
+    _, _, data = get_type_and_data(h_node)
     subtype = h_node.attrs["python_subdtype"]
     type_dict = {
         "<type 'int'>": int,

--- a/hickle/loaders/load_python.py
+++ b/hickle/loaders/load_python.py
@@ -7,13 +7,11 @@ NB: As these are for built-in types, they are critical to the functioning of hic
 
 """
 
+from six import integer_types, string_types
 from hickle.helpers import get_type_and_data
 
 import sys
 if sys.version_info.major == 3:
-    unicode = type(str)
-    str = type(bytes)
-    long = type(int)
     NoneType = type(None)
 else:
     from types import NoneType
@@ -31,7 +29,7 @@ def create_listlike_dataset(py_obj, h_group, call_id=0, **kwargs):
     dtype = str(type(py_obj))
     obj = list(py_obj)
     d = h_group.create_dataset('data_%i' % call_id, data=obj, **kwargs)
-    d.attrs["type"] = [dtype]
+    d.attrs["type"] = dtype
 
 
 def create_python_dtype_dataset(py_obj, h_group, call_id=0, **kwargs):
@@ -45,7 +43,7 @@ def create_python_dtype_dataset(py_obj, h_group, call_id=0, **kwargs):
     # kwarg compression etc does not work on scalars
     d = h_group.create_dataset('data_%i' % call_id, data=py_obj,
                                dtype=type(py_obj))     #, **kwargs)
-    d.attrs["type"] = ['python_dtype']
+    d.attrs["type"] = 'python_dtype'
     d.attrs['python_subdtype'] = str(type(py_obj))
 
 
@@ -59,12 +57,12 @@ def create_stringlike_dataset(py_obj, h_group, call_id=0, **kwargs):
     """
     if isinstance(py_obj, str):
         d = h_group.create_dataset('data_%i' % call_id, data=[py_obj], **kwargs)
-        d.attrs["type"] = ['string']
+        d.attrs["type"] = 'string'
     else:
         dt = h5.special_dtype(vlen=unicode)
         dset = h_group.create_dataset('data_%i' % call_id, shape=(1, ), dtype=dt, **kwargs)
         dset[0] = py_obj
-        dset.attrs['type'] = ['unicode']
+        dset.attrs['type'] = 'unicode'
 
 
 def create_none_dataset(py_obj, h_group, call_id=0, **kwargs):
@@ -76,7 +74,7 @@ def create_none_dataset(py_obj, h_group, call_id=0, **kwargs):
         call_id (int): index to identify object's relative location in the iterable.
     """
     d = h_group.create_dataset('data_%i' % call_id, data=[0], **kwargs)
-    d.attrs["type"] = ['none']
+    d.attrs["type"] = 'none'
 
 
 def load_list_dataset(h_node):
@@ -93,11 +91,11 @@ def load_set_dataset(h_node):
 
 def load_string_dataset(h_node):
     py_type, data = get_type_and_data(h_node)
-    return str(data[0])
+    return str(data)
 
 def load_unicode_dataset(h_node):
     py_type, data = get_type_and_data(h_node)
-    return unicode(data[0])
+    return unicode(data)
 
 def load_none_dataset(h_node):
     return None

--- a/hickle/loaders/load_python.py
+++ b/hickle/loaders/load_python.py
@@ -55,14 +55,8 @@ def create_stringlike_dataset(py_obj, h_group, call_id=0, **kwargs):
         h_group (h5.File.group): group to dump data into.
         call_id (int): index to identify object's relative location in the iterable.
     """
-    if isinstance(py_obj, str):
-        d = h_group.create_dataset('data_%i' % call_id, data=[py_obj], **kwargs)
-        d.attrs['base_type'] = 'string'
-    else:
-        dt = h5.special_dtype(vlen=unicode)
-        dset = h_group.create_dataset('data_%i' % call_id, shape=(1, ), dtype=dt, **kwargs)
-        dset[0] = py_obj
-        dset.attrs['base_type'] = 'unicode'
+    d = h_group.create_dataset('data_%i' % call_id, data=py_obj, **kwargs)
+    d.attrs['base_type'] = 'string' if isinstance(py_obj, str) else 'unicode'
 
 
 def create_none_dataset(py_obj, h_group, call_id=0, **kwargs):

--- a/hickle/loaders/load_python.py
+++ b/hickle/loaders/load_python.py
@@ -18,7 +18,7 @@ else:
 
 import h5py as h5
 
-def create_listlike_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
+def create_listlike_dataset(py_obj, h_group, name, **kwargs):
     """ Dumper for list, set, tuple
 
     Args:
@@ -28,11 +28,11 @@ def create_listlike_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
     """
 
     obj = list(py_obj)
-    d = h_group.create_dataset('data_%i' % call_id, data=obj, **kwargs)
-    d.attrs['base_type'] = base_type
+    d = h_group.create_dataset(name, data=obj, **kwargs)
+    return(d)
 
 
-def create_python_dtype_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
+def create_python_dtype_dataset(py_obj, h_group, name, **kwargs):
     """ dumps a python dtype object to h5py file
 
     Args:
@@ -41,13 +41,13 @@ def create_python_dtype_dataset(py_obj, base_type, h_group, call_id=0, **kwargs)
         call_id (int): index to identify object's relative location in the iterable.
     """
     # kwarg compression etc does not work on scalars
-    d = h_group.create_dataset('data_%i' % call_id, data=py_obj,
+    d = h_group.create_dataset(name, data=py_obj,
                                dtype=type(py_obj))     #, **kwargs)
-    d.attrs['base_type'] = 'python_dtype'
     d.attrs['python_subdtype'] = str(type(py_obj))
+    return(d)
 
 
-def create_stringlike_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
+def create_stringlike_dataset(py_obj, h_group, name, **kwargs):
     """ dumps a list object to h5py file
 
     Args:
@@ -55,11 +55,11 @@ def create_stringlike_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
         h_group (h5.File.group): group to dump data into.
         call_id (int): index to identify object's relative location in the iterable.
     """
-    d = h_group.create_dataset('data_%i' % call_id, data=py_obj, **kwargs)
-    d.attrs['base_type'] = 'string' if isinstance(py_obj, str) else 'unicode'
+    d = h_group.create_dataset(name, data=py_obj, **kwargs)
+    return(d)
 
 
-def create_none_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
+def create_none_dataset(py_obj, h_group, name, **kwargs):
     """ Dump None type to file
 
     Args:
@@ -67,8 +67,8 @@ def create_none_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
         h_group (h5.File.group): group to dump data into.
         call_id (int): index to identify object's relative location in the iterable.
     """
-    d = h_group.create_dataset('data_%i' % call_id, data=[0], **kwargs)
-    d.attrs['base_type'] = 'none'
+    d = h_group.create_dataset(name, data=[0], **kwargs)
+    return(d)
 
 
 def load_list_dataset(h_node):

--- a/hickle/loaders/load_python.py
+++ b/hickle/loaders/load_python.py
@@ -18,7 +18,7 @@ else:
 
 import h5py as h5
 
-def create_listlike_dataset(py_obj, h_group, call_id=0, **kwargs):
+def create_listlike_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
     """ Dumper for list, set, tuple
 
     Args:
@@ -26,13 +26,13 @@ def create_listlike_dataset(py_obj, h_group, call_id=0, **kwargs):
         h_group (h5.File.group): group to dump data into.
         call_id (int): index to identify object's relative location in the iterable.
     """
-    dtype = str(type(py_obj))
+
     obj = list(py_obj)
     d = h_group.create_dataset('data_%i' % call_id, data=obj, **kwargs)
-    d.attrs['base_type'] = dtype
+    d.attrs['base_type'] = base_type
 
 
-def create_python_dtype_dataset(py_obj, h_group, call_id=0, **kwargs):
+def create_python_dtype_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
     """ dumps a python dtype object to h5py file
 
     Args:
@@ -47,7 +47,7 @@ def create_python_dtype_dataset(py_obj, h_group, call_id=0, **kwargs):
     d.attrs['python_subdtype'] = str(type(py_obj))
 
 
-def create_stringlike_dataset(py_obj, h_group, call_id=0, **kwargs):
+def create_stringlike_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
     """ dumps a list object to h5py file
 
     Args:
@@ -59,7 +59,7 @@ def create_stringlike_dataset(py_obj, h_group, call_id=0, **kwargs):
     d.attrs['base_type'] = 'string' if isinstance(py_obj, str) else 'unicode'
 
 
-def create_none_dataset(py_obj, h_group, call_id=0, **kwargs):
+def create_none_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
     """ Dump None type to file
 
     Args:

--- a/hickle/loaders/load_python3.py
+++ b/hickle/loaders/load_python3.py
@@ -38,7 +38,7 @@ def get_py3_string_type(h_node):
     except:
         return None
 
-def create_listlike_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
+def create_listlike_dataset(py_obj, h_group, name, **kwargs):
     """ Dumper for list, set, tuple
 
     Args:
@@ -62,16 +62,16 @@ def create_listlike_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
         #print(obj, "HERE")
 
 
-    d = h_group.create_dataset('data_%i' % call_id, data=obj, **kwargs)
-    d.attrs['base_type'] = base_type
+    d = h_group.create_dataset(name, data=obj, **kwargs)
 
     # Need to add some metadata to aid in unpickling if it's a string type
     if py3_str_type is not None:
         d.attrs["py3_string_type"] = py3_str_type
+    return(d)
 
 
 
-def create_python_dtype_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
+def create_python_dtype_dataset(py_obj, h_group, name, **kwargs):
     """ dumps a python dtype object to h5py file
 
     Args:
@@ -80,13 +80,13 @@ def create_python_dtype_dataset(py_obj, base_type, h_group, call_id=0, **kwargs)
         call_id (int): index to identify object's relative location in the iterable.
     """
     # kwarg compression etc does not work on scalars
-    d = h_group.create_dataset('data_%i' % call_id, data=py_obj,
+    d = h_group.create_dataset(name, data=py_obj,
                                dtype=type(py_obj))     #, **kwargs)
-    d.attrs['base_type'] = base_type
     d.attrs['python_subdtype'] = bytes(str(type(py_obj)), 'ascii')
+    return(d)
 
 
-def create_stringlike_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
+def create_stringlike_dataset(py_obj, h_group, name, **kwargs):
     """ dumps a list object to h5py file
 
     Args:
@@ -94,10 +94,10 @@ def create_stringlike_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
         h_group (h5.File.group): group to dump data into.
         call_id (int): index to identify object's relative location in the iterable.
     """
-    d = h_group.create_dataset('data_%i' % call_id, data=py_obj, **kwargs)
-    d.attrs['base_type'] = b'bytes' if isinstance(py_obj, bytes) else b'string'
+    d = h_group.create_dataset(name, data=py_obj, **kwargs)
+    return(d)
 
-def create_none_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
+def create_none_dataset(py_obj, h_group, name, **kwargs):
     """ Dump None type to file
 
     Args:
@@ -105,8 +105,8 @@ def create_none_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
         h_group (h5.File.group): group to dump data into.
         call_id (int): index to identify object's relative location in the iterable.
     """
-    d = h_group.create_dataset('data_%i' % call_id, data=[0], **kwargs)
-    d.attrs['base_type'] = b'none'
+    d = h_group.create_dataset(name, data=[0], **kwargs)
+    return(d)
 
 
 def load_list_dataset(h_node):

--- a/hickle/loaders/load_python3.py
+++ b/hickle/loaders/load_python3.py
@@ -110,7 +110,7 @@ def create_none_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
 
 
 def load_list_dataset(h_node):
-    py_type, data = get_type_and_data(h_node)
+    _, _, data = get_type_and_data(h_node)
     py3_str_type = get_py3_string_type(h_node)
 
     if py3_str_type == b"<class 'bytes'>":
@@ -130,22 +130,22 @@ def load_set_dataset(h_node):
     return set(data)
 
 def load_bytes_dataset(h_node):
-    py_type, data = get_type_and_data(h_node)
+    _, _, data = get_type_and_data(h_node)
     return bytes(data)
 
 def load_string_dataset(h_node):
-    py_type, data = get_type_and_data(h_node)
+    _, _, data = get_type_and_data(h_node)
     return str(data)
 
 def load_unicode_dataset(h_node):
-    py_type, data = get_type_and_data(h_node)
+    _, _, data = get_type_and_data(h_node)
     return unicode(data)
 
 def load_none_dataset(h_node):
     return None
 
 def load_pickled_data(h_node):
-    py_type, data = get_type_and_data(h_node)
+    _, _, data = get_type_and_data(h_node)
     try:
         import cPickle as pickle
     except ModuleNotFoundError:
@@ -154,7 +154,7 @@ def load_pickled_data(h_node):
 
 
 def load_python_dtype_dataset(h_node):
-    py_type, data = get_type_and_data(h_node)
+    _, _, data = get_type_and_data(h_node)
     subtype = h_node.attrs["python_subdtype"]
     type_dict = {
         b"<class 'int'>": int,

--- a/hickle/loaders/load_python3.py
+++ b/hickle/loaders/load_python3.py
@@ -170,17 +170,17 @@ def load_python_dtype_dataset(h_node):
 
 
 types_dict = {
-    list:        create_listlike_dataset,
-    tuple:       create_listlike_dataset,
-    set:         create_listlike_dataset,
-    bytes:         create_stringlike_dataset,
-    str:           create_stringlike_dataset,
-    #bytearray:     create_stringlike_dataset,
-    int:         create_python_dtype_dataset,
-    float:       create_python_dtype_dataset,
-    bool:        create_python_dtype_dataset,
-    complex:     create_python_dtype_dataset,
-    type(None):    create_none_dataset,
+    list:        (create_listlike_dataset, b"<class 'list'>"),
+    tuple:       (create_listlike_dataset, b"<class 'tuple'>"),
+    set:         (create_listlike_dataset, b"<class 'set'>"),
+    bytes:       (create_stringlike_dataset, b"bytes"),
+    str:         (create_stringlike_dataset, b"string"),
+    # bytearray:   (create_stringlike_dataset, b"bytes"),
+    int:         (create_python_dtype_dataset, b"python_dtype"),
+    float:       (create_python_dtype_dataset, b"python_dtype"),
+    bool:        (create_python_dtype_dataset, b"python_dtype"),
+    complex:     (create_python_dtype_dataset, b"python_dtype"),
+    type(None):  (create_none_dataset, b"none"),
 }
 
 hkl_types_dict = {

--- a/hickle/loaders/load_python3.py
+++ b/hickle/loaders/load_python3.py
@@ -33,7 +33,7 @@ def get_py3_string_type(h_node):
 
     """
     try:
-        py_type = h_node.attrs["py3_string_type"][0]
+        py_type = h_node.attrs["py3_string_type"]
         return py_type
     except:
         return None
@@ -64,11 +64,11 @@ def create_listlike_dataset(py_obj, h_group, call_id=0, **kwargs):
 
 
     d = h_group.create_dataset('data_%i' % call_id, data=obj, **kwargs)
-    d.attrs["type"] = [bytes(dtype, 'ascii')]
+    d.attrs["type"] = bytes(dtype, 'ascii')
 
     # Need to add some metadata to aid in unpickling if it's a string type
     if py3_str_type is not None:
-        d.attrs["py3_string_type"] = [py3_str_type]
+        d.attrs["py3_string_type"] = py3_str_type
 
 
 
@@ -83,7 +83,7 @@ def create_python_dtype_dataset(py_obj, h_group, call_id=0, **kwargs):
     # kwarg compression etc does not work on scalars
     d = h_group.create_dataset('data_%i' % call_id, data=py_obj,
                                dtype=type(py_obj))     #, **kwargs)
-    d.attrs["type"] = [b'python_dtype']
+    d.attrs["type"] = b'python_dtype'
     d.attrs['python_subdtype'] = bytes(str(type(py_obj)), 'ascii')
 
 
@@ -97,12 +97,12 @@ def create_stringlike_dataset(py_obj, h_group, call_id=0, **kwargs):
     """
     if isinstance(py_obj, bytes):
         d = h_group.create_dataset('data_%i' % call_id, data=[py_obj], **kwargs)
-        d.attrs["type"] = [b'bytes']
+        d.attrs["type"] = b'bytes'
     elif isinstance(py_obj, str):
         dt = h5.special_dtype(vlen=str)
         dset = h_group.create_dataset('data_%i' % call_id, shape=(1, ), dtype=dt, **kwargs)
         dset[0] = py_obj
-        dset.attrs['type'] = [b'string']
+        dset.attrs['type'] = b'string'
 
 def create_none_dataset(py_obj, h_group, call_id=0, **kwargs):
     """ Dump None type to file
@@ -113,7 +113,7 @@ def create_none_dataset(py_obj, h_group, call_id=0, **kwargs):
         call_id (int): index to identify object's relative location in the iterable.
     """
     d = h_group.create_dataset('data_%i' % call_id, data=[0], **kwargs)
-    d.attrs["type"] = [b'none']
+    d.attrs["type"] = b'none'
 
 
 def load_list_dataset(h_node):
@@ -138,15 +138,15 @@ def load_set_dataset(h_node):
 
 def load_bytes_dataset(h_node):
     py_type, data = get_type_and_data(h_node)
-    return bytes(data[0])
+    return bytes(data)
 
 def load_string_dataset(h_node):
     py_type, data = get_type_and_data(h_node)
-    return str(data[0])
+    return str(data)
 
 def load_unicode_dataset(h_node):
     py_type, data = get_type_and_data(h_node)
-    return unicode(data[0])
+    return unicode(data)
 
 def load_none_dataset(h_node):
     return None
@@ -157,7 +157,7 @@ def load_pickled_data(h_node):
         import cPickle as pickle
     except ModuleNotFoundError:
         import pickle
-    return pickle.loads(data[0])
+    return pickle.loads(data)
 
 
 def load_python_dtype_dataset(h_node):

--- a/hickle/loaders/load_python3.py
+++ b/hickle/loaders/load_python3.py
@@ -38,7 +38,7 @@ def get_py3_string_type(h_node):
     except:
         return None
 
-def create_listlike_dataset(py_obj, h_group, call_id=0, **kwargs):
+def create_listlike_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
     """ Dumper for list, set, tuple
 
     Args:
@@ -46,7 +46,6 @@ def create_listlike_dataset(py_obj, h_group, call_id=0, **kwargs):
         h_group (h5.File.group): group to dump data into.
         call_id (int): index to identify object's relative location in the iterable.
     """
-    dtype = str(type(py_obj))
     obj = list(py_obj)
 
     # h5py does not handle Py3 'str' objects well. Need to catch this
@@ -64,7 +63,7 @@ def create_listlike_dataset(py_obj, h_group, call_id=0, **kwargs):
 
 
     d = h_group.create_dataset('data_%i' % call_id, data=obj, **kwargs)
-    d.attrs['base_type'] = bytes(dtype, 'ascii')
+    d.attrs['base_type'] = base_type
 
     # Need to add some metadata to aid in unpickling if it's a string type
     if py3_str_type is not None:
@@ -72,7 +71,7 @@ def create_listlike_dataset(py_obj, h_group, call_id=0, **kwargs):
 
 
 
-def create_python_dtype_dataset(py_obj, h_group, call_id=0, **kwargs):
+def create_python_dtype_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
     """ dumps a python dtype object to h5py file
 
     Args:
@@ -83,11 +82,11 @@ def create_python_dtype_dataset(py_obj, h_group, call_id=0, **kwargs):
     # kwarg compression etc does not work on scalars
     d = h_group.create_dataset('data_%i' % call_id, data=py_obj,
                                dtype=type(py_obj))     #, **kwargs)
-    d.attrs['base_type'] = b'python_dtype'
+    d.attrs['base_type'] = base_type
     d.attrs['python_subdtype'] = bytes(str(type(py_obj)), 'ascii')
 
 
-def create_stringlike_dataset(py_obj, h_group, call_id=0, **kwargs):
+def create_stringlike_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
     """ dumps a list object to h5py file
 
     Args:
@@ -98,7 +97,7 @@ def create_stringlike_dataset(py_obj, h_group, call_id=0, **kwargs):
     d = h_group.create_dataset('data_%i' % call_id, data=py_obj, **kwargs)
     d.attrs['base_type'] = b'bytes' if isinstance(py_obj, bytes) else b'string'
 
-def create_none_dataset(py_obj, h_group, call_id=0, **kwargs):
+def create_none_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
     """ Dump None type to file
 
     Args:

--- a/hickle/loaders/load_python3.py
+++ b/hickle/loaders/load_python3.py
@@ -64,7 +64,7 @@ def create_listlike_dataset(py_obj, h_group, call_id=0, **kwargs):
 
 
     d = h_group.create_dataset('data_%i' % call_id, data=obj, **kwargs)
-    d.attrs["type"] = bytes(dtype, 'ascii')
+    d.attrs['base_type'] = bytes(dtype, 'ascii')
 
     # Need to add some metadata to aid in unpickling if it's a string type
     if py3_str_type is not None:
@@ -83,7 +83,7 @@ def create_python_dtype_dataset(py_obj, h_group, call_id=0, **kwargs):
     # kwarg compression etc does not work on scalars
     d = h_group.create_dataset('data_%i' % call_id, data=py_obj,
                                dtype=type(py_obj))     #, **kwargs)
-    d.attrs["type"] = b'python_dtype'
+    d.attrs['base_type'] = b'python_dtype'
     d.attrs['python_subdtype'] = bytes(str(type(py_obj)), 'ascii')
 
 
@@ -97,12 +97,12 @@ def create_stringlike_dataset(py_obj, h_group, call_id=0, **kwargs):
     """
     if isinstance(py_obj, bytes):
         d = h_group.create_dataset('data_%i' % call_id, data=[py_obj], **kwargs)
-        d.attrs["type"] = b'bytes'
+        d.attrs['base_type'] = b'bytes'
     elif isinstance(py_obj, str):
         dt = h5.special_dtype(vlen=str)
         dset = h_group.create_dataset('data_%i' % call_id, shape=(1, ), dtype=dt, **kwargs)
         dset[0] = py_obj
-        dset.attrs['type'] = b'string'
+        dset.attrs['base_type'] = b'string'
 
 def create_none_dataset(py_obj, h_group, call_id=0, **kwargs):
     """ Dump None type to file
@@ -113,7 +113,7 @@ def create_none_dataset(py_obj, h_group, call_id=0, **kwargs):
         call_id (int): index to identify object's relative location in the iterable.
     """
     d = h_group.create_dataset('data_%i' % call_id, data=[0], **kwargs)
-    d.attrs["type"] = b'none'
+    d.attrs['base_type'] = b'none'
 
 
 def load_list_dataset(h_node):

--- a/hickle/loaders/load_python3.py
+++ b/hickle/loaders/load_python3.py
@@ -95,14 +95,8 @@ def create_stringlike_dataset(py_obj, h_group, call_id=0, **kwargs):
         h_group (h5.File.group): group to dump data into.
         call_id (int): index to identify object's relative location in the iterable.
     """
-    if isinstance(py_obj, bytes):
-        d = h_group.create_dataset('data_%i' % call_id, data=[py_obj], **kwargs)
-        d.attrs['base_type'] = b'bytes'
-    elif isinstance(py_obj, str):
-        dt = h5.special_dtype(vlen=str)
-        dset = h_group.create_dataset('data_%i' % call_id, shape=(1, ), dtype=dt, **kwargs)
-        dset[0] = py_obj
-        dset.attrs['base_type'] = b'string'
+    d = h_group.create_dataset('data_%i' % call_id, data=py_obj, **kwargs)
+    d.attrs['base_type'] = b'bytes' if isinstance(py_obj, bytes) else b'string'
 
 def create_none_dataset(py_obj, h_group, call_id=0, **kwargs):
     """ Dump None type to file

--- a/hickle/loaders/load_scipy.py
+++ b/hickle/loaders/load_scipy.py
@@ -21,7 +21,7 @@ def check_is_scipy_sparse_array(py_obj):
     return is_sparse
 
 
-def create_sparse_dataset(py_obj, h_group, call_id=0, **kwargs):
+def create_sparse_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
     """ dumps an sparse array to h5py file
 
     Args:

--- a/hickle/loaders/load_scipy.py
+++ b/hickle/loaders/load_scipy.py
@@ -19,6 +19,12 @@ else:
 
 from hickle.helpers import get_type_and_data
 
+
+def return_first(x):
+    """ Return first element of a list """
+    return x[0]
+
+
 def check_is_scipy_sparse_array(py_obj):
     """ Check if a python object is a scipy sparse array
 
@@ -36,7 +42,7 @@ def check_is_scipy_sparse_array(py_obj):
     return is_sparse
 
 
-def create_sparse_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
+def create_sparse_dataset(py_obj, h_group, name, **kwargs):
     """ dumps an sparse array to h5py file
 
     Args:
@@ -44,7 +50,7 @@ def create_sparse_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
         h_group (h5.File.group): group to dump data into.
         call_id (int): index to identify object's relative location in the iterable.
     """
-    h_sparsegroup = h_group.create_group('data_%i' % call_id)
+    h_sparsegroup = h_group.create_group(name)
     data = h_sparsegroup.create_dataset('data', data=py_obj.data, **kwargs)
     indices = h_sparsegroup.create_dataset('indices', data=py_obj.indices, **kwargs)
     indptr = h_sparsegroup.create_dataset('indptr', data=py_obj.indptr, **kwargs)
@@ -57,15 +63,16 @@ def create_sparse_dataset(py_obj, base_type, h_group, call_id=0, **kwargs):
     elif isinstance(py_obj, sparse.bsr_matrix):
         type_str = 'bsr'
 
+    h_sparsegroup.attrs['type'] = np.array(pickle.dumps(return_first))
     h_sparsegroup.attrs['base_type'] = ('%s_matrix' % type_str).encode('ascii')
-    data.attrs['type']               = np.array(pickle.dumps(py_obj.__class__))
-    data.attrs['base_type']          = ("%s_matrix_data" % type_str).encode('ascii')
     indices.attrs['type']               = np.array(pickle.dumps(NoneType))
     indices.attrs['base_type']       = ("%s_matrix_indices" % type_str).encode('ascii')
     indptr.attrs['type']               = np.array(pickle.dumps(NoneType))
     indptr.attrs['base_type']        = ("%s_matrix_indptr" % type_str).encode('ascii')
     shape.attrs['type']               = np.array(pickle.dumps(NoneType))
     shape.attrs['base_type']         = ("%s_matrix_shape" % type_str).encode('ascii')
+
+    return(data)
 
 def load_sparse_matrix_data(h_node):
 

--- a/hickle/loaders/load_scipy.py
+++ b/hickle/loaders/load_scipy.py
@@ -43,17 +43,17 @@ def create_sparse_dataset(py_obj, h_group, call_id=0, **kwargs):
         type_str = 'bsr'
 
     if six.PY2:
-        h_sparsegroup.attrs["type"] = b'%s_matrix' % type_str
-        data.attrs["type"]          = b"%s_matrix_data" % type_str
-        indices.attrs["type"]       = b"%s_matrix_indices" % type_str
-        indptr.attrs["type"]        = b"%s_matrix_indptr" % type_str
-        shape.attrs["type"]         = b"%s_matrix_shape" % type_str
+        h_sparsegroup.attrs['base_type'] = b'%s_matrix' % type_str
+        data.attrs['base_type']          = b"%s_matrix_data" % type_str
+        indices.attrs['base_type']       = b"%s_matrix_indices" % type_str
+        indptr.attrs['base_type']        = b"%s_matrix_indptr" % type_str
+        shape.attrs['base_type']         = b"%s_matrix_shape" % type_str
     else:
-        h_sparsegroup.attrs["type"] = bytes(str('%s_matrix' % type_str), 'ascii')
-        data.attrs["type"]          = bytes(str("%s_matrix_data" % type_str), 'ascii')
-        indices.attrs["type"]       = bytes(str("%s_matrix_indices" % type_str), 'ascii')
-        indptr.attrs["type"]        = bytes(str("%s_matrix_indptr" % type_str), 'ascii')
-        shape.attrs["type"]         = bytes(str("%s_matrix_shape" % type_str), 'ascii')
+        h_sparsegroup.attrs['base_type'] = bytes(str('%s_matrix' % type_str), 'ascii')
+        data.attrs['base_type']          = bytes(str("%s_matrix_data" % type_str), 'ascii')
+        indices.attrs['base_type']       = bytes(str("%s_matrix_indices" % type_str), 'ascii')
+        indptr.attrs['base_type']        = bytes(str("%s_matrix_indptr" % type_str), 'ascii')
+        shape.attrs['base_type']         = bytes(str("%s_matrix_shape" % type_str), 'ascii')
 
 def load_sparse_matrix_data(h_node):
 

--- a/hickle/loaders/load_scipy.py
+++ b/hickle/loaders/load_scipy.py
@@ -43,17 +43,17 @@ def create_sparse_dataset(py_obj, h_group, call_id=0, **kwargs):
         type_str = 'bsr'
 
     if six.PY2:
-        h_sparsegroup.attrs["type"] = [b'%s_matrix' % type_str]
-        data.attrs["type"]          = [b"%s_matrix_data" % type_str]
-        indices.attrs["type"]       = [b"%s_matrix_indices" % type_str]
-        indptr.attrs["type"]        = [b"%s_matrix_indptr" % type_str]
-        shape.attrs["type"]         = [b"%s_matrix_shape" % type_str]
+        h_sparsegroup.attrs["type"] = b'%s_matrix' % type_str
+        data.attrs["type"]          = b"%s_matrix_data" % type_str
+        indices.attrs["type"]       = b"%s_matrix_indices" % type_str
+        indptr.attrs["type"]        = b"%s_matrix_indptr" % type_str
+        shape.attrs["type"]         = b"%s_matrix_shape" % type_str
     else:
-        h_sparsegroup.attrs["type"] = [bytes(str('%s_matrix' % type_str), 'ascii')]
-        data.attrs["type"]          = [bytes(str("%s_matrix_data" % type_str), 'ascii')]
-        indices.attrs["type"]       = [bytes(str("%s_matrix_indices" % type_str), 'ascii')]
-        indptr.attrs["type"]        = [bytes(str("%s_matrix_indptr" % type_str), 'ascii')]
-        shape.attrs["type"]         = [bytes(str("%s_matrix_shape" % type_str), 'ascii')]
+        h_sparsegroup.attrs["type"] = bytes(str('%s_matrix' % type_str), 'ascii')
+        data.attrs["type"]          = bytes(str("%s_matrix_data" % type_str), 'ascii')
+        indices.attrs["type"]       = bytes(str("%s_matrix_indices" % type_str), 'ascii')
+        indptr.attrs["type"]        = bytes(str("%s_matrix_indptr" % type_str), 'ascii')
+        shape.attrs["type"]         = bytes(str("%s_matrix_shape" % type_str), 'ascii')
 
 def load_sparse_matrix_data(h_node):
 

--- a/hickle/lookup.py
+++ b/hickle/lookup.py
@@ -39,10 +39,6 @@ container_key_types_dict: mapping specifically for converting hickled dict data 
         "<type 'unicode'>": unicode
         }
 
-5) types_not_to_sort
-type_not_to_sort is a list of hickle type attributes that may be hierarchical,
-but don't require sorting by integer index.
-
 ## Extending hickle to add support for other classes and types
 
 The process to add new load/dump capabilities is as follows:
@@ -65,11 +61,7 @@ The process to add new load/dump capabilities is as follows:
 from six import PY2
 from ast import literal_eval
 
-def return_first(x):
-    """ Return first element of a list """
-    return x[0]
-
-def load_nothing(h_hode):
+def load_nothing(h_node):
     pass
 
 types_dict = {}
@@ -85,9 +77,9 @@ container_types_dict = {
     b"<class 'list'>": list,
     b"<class 'tuple'>": tuple,
     b"<class 'set'>": set,
-    b"csr_matrix":  return_first,
-    b"csc_matrix": return_first,
-    b"bsr_matrix": return_first
+    b"csr_matrix":  None,
+    b"csc_matrix": None,
+    b"bsr_matrix": None
     }
 
 # Technically, any hashable object can be used, for now sticking with built-in types

--- a/hickle/lookup.py
+++ b/hickle/lookup.py
@@ -165,7 +165,7 @@ def register_class(myclass_type, hkl_str, dump_function, load_function,
         ndarray_check_fn (function def): function to use to check if
 
     """
-    types_dict.update({myclass_type: dump_function})
+    types_dict.update({myclass_type: (dump_function, hkl_str)})
     hkl_types_dict.update({hkl_str: load_function})
     if to_sort == False:
         types_not_to_sort.append(hkl_str)

--- a/hickle/lookup.py
+++ b/hickle/lookup.py
@@ -62,7 +62,7 @@ The process to add new load/dump capabilities is as follows:
         raise
 """
 
-import six
+from six import PY2
 from ast import literal_eval
 
 def return_first(x):
@@ -106,12 +106,12 @@ container_key_types_dict = {
     b"<class 'tuple'>": literal_eval
     }
 
-if six.PY2:
+if PY2:
     container_key_types_dict[b"<type 'unicode'>"] = literal_eval
     container_key_types_dict[b"<type 'long'>"] = long
 
 # Add loaders for built-in python types
-if six.PY2:
+if PY2:
     from .loaders.load_python import types_dict as py_types_dict
     from .loaders.load_python import hkl_types_dict as py_hkl_types_dict
 else:

--- a/hickle/tests/test_hickle.py
+++ b/hickle/tests/test_hickle.py
@@ -14,6 +14,7 @@ import os
 import six
 import time
 from pprint import pprint
+from collections import OrderedDict as odict
 
 from py.path import local
 
@@ -199,6 +200,20 @@ def test_dict():
             print(dd[k])
             print(type(dd_hkl[k]), type(dd[k]))
             raise
+
+
+def test_odict():
+    """ Test ordered dictionary dumping and loading """
+    filename, mode = 'test.hdf5', 'w'
+
+    od = odict(((3, [3, 0.1]), (7, [5, 0.1]), (5, [3, 0.1])))
+    dump(od, filename, mode)
+    od_hkl = load(filename)
+
+    assert od.keys() == od_hkl.keys()
+
+    for od_item, od_hkl_item in zip(od.items(), od_hkl.items()):
+        assert od_item == od_hkl_item
 
 
 def test_empty_dict():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
-h5py
-numpy
 dill
+h5py>=2.8.0
+numpy>=1.8
+six>=1.11.0
+


### PR DESCRIPTION
This PR adds support for hickling objects that are subinstances of classes that hickle supports.
So, for example, anything that subclasses a `dict` can now be hickled properly as well.
This PR also includes the changes made in #109.
Finally, I have removed all instances where the type of a hickled dataset was saved as a list instead of just a normal string.

As it is required to save a bit more data in the HDF5-file now, previously made hickle-files are not supported.