### PR TITLE
Restructuring for v4.0.0

### DIFF
--- a/hickle/__init__.py
+++ b/hickle/__init__.py
@@ -1,4 +1,3 @@
 from .hickle import dump, load
-from .hickle import __version__
-
+from .__version__ import __version__
 

--- a/hickle/__version__.py
+++ b/hickle/__version__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+"""
+Hickle Version
+==============
+Stores the different versions of the *Hickle* package.
+
+"""
+
+
+# %% VERSIONS
+# Default/Latest/Current version
+__version__ = '4.0.0'
+

--- a/hickle/hickle.py
+++ b/hickle/hickle.py
@@ -153,7 +153,7 @@ class H5FileWrapper(h5.File):
         return group
 
 
-def file_opener(f, mode='r', track_times=True):
+def file_opener(f, path, mode='r', track_times=True):
     """ A file opener helper function with some error handling.  This can open
     files through a file object, a h5py file, or just the filename.
 
@@ -167,6 +167,10 @@ def file_opener(f, mode='r', track_times=True):
 
     # Assume that we will have to close the file after dump or load
     close_flag = True
+
+    # Make sure that the given path always starts with '/'
+    if not path.startswith('/'):
+        path = '/%s' % (path)
 
     # Were we handed a file object or just a file name string?
     if isinstance(f, (file, io.TextIOWrapper)):
@@ -184,13 +188,23 @@ def file_opener(f, mode='r', track_times=True):
         h5f = f
         # Since this file was already open, do not close the file afterward
         close_flag = False
+    elif isinstance(f, (h5._hl.group.Group)):
+        try:
+            filename = f.file.filename
+        except ValueError:
+            raise ClosedFileError
+        h5f = f.file
+
+        # Combine given path with path to this group
+        path = ''.join([f.name, path])
+        close_flag = False
     else:
         print(f.__class__)
         raise FileError
 
     h5f.__class__ = H5FileWrapper
     h5f.track_times = track_times
-    return(h5f, close_flag)
+    return(h5f, path, close_flag)
 
 
 ###########
@@ -257,7 +271,7 @@ def dump(py_obj, file_obj, mode='w', track_times=True, path='/', **kwargs):
 
     Args:
     obj (object): python object to store in a Hickle
-    file: file object, filename string, or h5py.File object
+    file: file object, filename string, h5py.File object or h5py.Group object
             file in which to store the object. A h5py.File or a filename is also
             acceptable.
     mode (str): optional argument, 'r' (read only), 'w' (write) or 'a' (append).
@@ -266,7 +280,7 @@ def dump(py_obj, file_obj, mode='w', track_times=True, path='/', **kwargs):
             lzf (+ szip, if installed)
     track_times (bool): optional argument. If set to False, repeated hickling will produce
             identical files.
-    path (str): path within hdf5 file to save data to. Defaults to root /
+    path (str): path within hdf5 file or group to save data to. Defaults to root /
     """
 
     # Make sure that file is not closed unless modified
@@ -275,7 +289,7 @@ def dump(py_obj, file_obj, mode='w', track_times=True, path='/', **kwargs):
 
     try:
         # Open the file
-        h5f, close_flag = file_opener(file_obj, mode, track_times)
+        h5f, path, close_flag = file_opener(file_obj, path, mode, track_times)
 
         # Log which version of python was used to generate the hickle file
         pv = sys.version_info
@@ -539,7 +553,7 @@ def load(fileobj, path='/', safe=True):
     close_flag = False
 
     try:
-        h5f, close_flag = file_opener(fileobj)
+        h5f, path, close_flag = file_opener(fileobj, path)
         h_root_group = h5f.get(path)
         try:
             assert 'CLASS' in h_root_group.attrs.keys()

--- a/hickle/hickle.py
+++ b/hickle/hickle.py
@@ -32,9 +32,10 @@ import numpy as np
 import h5py as h5
 
 
-from .helpers import get_type, sort_keys, check_is_iterable, check_iterable_item_type
-from .lookup import types_dict, hkl_types_dict, types_not_to_sort, \
-    container_types_dict, container_key_types_dict, check_is_ndarray_like
+from hickle.__version__ import __version__
+from hickle.helpers import get_type, sort_keys, check_is_iterable, check_iterable_item_type
+from hickle.lookup import (types_dict, hkl_types_dict, types_not_to_sort,
+    container_types_dict, container_key_types_dict, check_is_ndarray_like)
 
 
 try:
@@ -61,11 +62,6 @@ import warnings
 # Make several aliases for Python2/Python3 compatibility
 if PY3:
     file = io.TextIOWrapper
-
-try:
-    __version__ = get_distribution('hickle').version
-except DistributionNotFound:
-    __version__ = '0.0.0 - please install via pip/setup.py'
 
 ##################
 # Error handling #

--- a/hickle/hickle.py
+++ b/hickle/hickle.py
@@ -434,7 +434,7 @@ types_dict[dict] = (create_dict_dataset, b"<class 'dict'>")
 
 
 def no_match(py_obj, h_group, name, **kwargs):
-    """ If no match is made, raise an exception
+    """ If no match is made, raise a warning
 
     Args:
         py_obj: python object to dump; default if item is not matched.

--- a/hickle/loaders/load_python.py
+++ b/hickle/loaders/load_python.py
@@ -42,10 +42,10 @@ def create_python_dtype_dataset(py_obj, h_group, name, **kwargs):
     """
 
     # Determine the subdtype of the given py_obj
-    subdtype = bytes(str(type(py_obj)))
+    subdtype = str(type(py_obj))
 
     # If py_obj is an integer and cannot be stored in 64-bits, convert to str
-    if isinstance(py_obj, int) and (py_obj.bit_length() > 64):
+    if isinstance(py_obj, integer_types) and (py_obj.bit_length() > 64):
         py_obj = str(py_obj)
 
     # kwarg compression etc does not work on scalars

--- a/hickle/loaders/load_python.py
+++ b/hickle/loaders/load_python.py
@@ -40,10 +40,17 @@ def create_python_dtype_dataset(py_obj, h_group, name, **kwargs):
         h_group (h5.File.group): group to dump data into.
         call_id (int): index to identify object's relative location in the iterable.
     """
+
+    # Determine the subdtype of the given py_obj
+    subdtype = bytes(str(type(py_obj)))
+
+    # If py_obj is an integer and cannot be stored in 64-bits, convert to str
+    if isinstance(py_obj, int) and (py_obj.bit_length() > 64):
+        py_obj = str(py_obj)
+
     # kwarg compression etc does not work on scalars
-    d = h_group.create_dataset(name, data=py_obj,
-                               dtype=type(py_obj))     #, **kwargs)
-    d.attrs['python_subdtype'] = str(type(py_obj))
+    d = h_group.create_dataset(name, data=py_obj)     #, **kwargs)
+    d.attrs['python_subdtype'] = subdtype
     return(d)
 
 

--- a/hickle/loaders/load_python3.py
+++ b/hickle/loaders/load_python3.py
@@ -85,7 +85,7 @@ def create_python_dtype_dataset(py_obj, h_group, name, **kwargs):
 
     # If py_obj is an integer and cannot be stored in 64-bits, convert to str
     if isinstance(py_obj, int) and (py_obj.bit_length() > 64):
-        py_obj = str(py_obj)
+        py_obj = bytes(str(py_obj), 'ascii')
 
     # kwarg compression etc does not work on scalars
     d = h_group.create_dataset(name, data=py_obj)     #, **kwargs)

--- a/hickle/loaders/load_python3.py
+++ b/hickle/loaders/load_python3.py
@@ -79,10 +79,17 @@ def create_python_dtype_dataset(py_obj, h_group, name, **kwargs):
         h_group (h5.File.group): group to dump data into.
         call_id (int): index to identify object's relative location in the iterable.
     """
+
+    # Determine the subdtype of the given py_obj
+    subdtype = bytes(str(type(py_obj)), 'ascii')
+
+    # If py_obj is an integer and cannot be stored in 64-bits, convert to str
+    if isinstance(py_obj, int) and (py_obj.bit_length() > 64):
+        py_obj = str(py_obj)
+
     # kwarg compression etc does not work on scalars
-    d = h_group.create_dataset(name, data=py_obj,
-                               dtype=type(py_obj))     #, **kwargs)
-    d.attrs['python_subdtype'] = bytes(str(type(py_obj)), 'ascii')
+    d = h_group.create_dataset(name, data=py_obj)     #, **kwargs)
+    d.attrs['python_subdtype'] = subdtype
     return(d)
 
 

--- a/hickle/tests/test_hickle.py
+++ b/hickle/tests/test_hickle.py
@@ -91,6 +91,14 @@ def test_unicode2():
     else:
         pass
 
+
+def test_65bit_int():
+    i = 2**65-1
+    dump(i, 'test.hdf5')
+    i_hkl = load('test.hdf5')
+    assert i == i_hkl
+
+
 def test_list():
     """ Dumping and loading a list """
     filename, mode = 'test_list.h5', 'w'

--- a/hickle/tests/test_hickle.py
+++ b/hickle/tests/test_hickle.py
@@ -486,6 +486,19 @@ def test_file_open_close():
         print("Tests: Closed file exception caught")
 
 
+def test_hdf5_group():
+    import h5py
+    file = h5py.File('test.hdf5', 'w')
+    group = file.create_group('test_group')
+    a = np.arange(5)
+
+    dump(a, group, path='deeper/and_deeper')
+    file.close()
+
+    a_hkl = load('test.hdf5', path='/test_group/deeper/and_deeper')
+    assert np.allclose(a_hkl, a)
+
+
 def test_list_order():
     """ https://github.com/telegraphic/hickle/issues/26 """
     d = [np.arange(n + 1) for n in range(20)]
@@ -793,6 +806,7 @@ if __name__ == '__main__':
     test_scalar_compression()
     test_complex()
     test_file_open_close()
+    test_hdf5_group()
     test_dict_none()
     test_none()
     test_masked_dict()
@@ -800,6 +814,7 @@ if __name__ == '__main__':
     test_set()
     test_numpy()
     test_dict()
+    test_odict()
     test_empty_dict()
     test_compression()
     test_masked()

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,12 @@
 # TEST: twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 # twine upload dist/*
 
+from codecs import open
+import re
+
 from setuptools import setup, find_packages
 import sys
 
-version = '3.4.6'
 author  = 'Danny Price'
 
 with open("README.md", "r") as fh:
@@ -20,6 +22,13 @@ with open("requirements.txt", 'r') as fh:
 
 with open("requirements_test.txt", 'r') as fh:
     test_requirements = fh.read().splitlines()
+
+# Read the __version__.py file
+with open('hickle/__version__.py', 'r') as f:
+    vf = f.read()
+
+# Obtain version from read-in __version__.py file
+version = re.search(r"^_*version_* = ['\"]([^'\"]*)['\"]", vf, re.M).group(1)
 
 setup(name='hickle',
       version=version,


### PR DESCRIPTION
Will just make this PR already in advance.
I will keep updating this post with the changes I have made.

- Version is now stored in a single place;
- HDF5 groups can now be dumped to and loaded from;
- Integers using Python's arbitrary-precision (integers larger than 64-bit) can now be dumped and loaded properly;