### PR TITLE
Quick fix for scalar compression issue #140 (obsoleted by #138)

### DIFF
--- a/hickle/hickle.py
+++ b/hickle/hickle.py
@@ -243,6 +243,16 @@ def dump(py_obj, file_obj, mode='w', path='/', **kwargs):
         h_root_group.attrs["HICKLE_VERSION"] = __version__
         h_root_group.attrs["HICKLE_PYTHON_VERSION"] = py_ver
 
+        no_compression_args = {
+            key:value
+            for key,value in kwargs.items()
+            if key not in {
+                "compression","shuffle","compression_opts","chunks","fletcher32","scaleoffset"
+            }
+        }
+        if len(no_compression_args) != len(kwargs):
+            warnings.warn("HDF5 compressed datasets currently not supported by hickle !!")
+            kwargs = no_compression_args
         _dump(py_obj, h_root_group, **kwargs)
     finally:
         # Close the file if requested.

--- a/hickle/tests/test_hickle.py
+++ b/hickle/tests/test_hickle.py
@@ -821,7 +821,11 @@ def test_scalar_compression():
     """
     data = {'a': 0, 'b': np.float(2), 'c': True}
 
-    dump(data, "test.hkl", compression='gzip')
+    with pytest.warns(
+        UserWarning,
+        match = r"HDF5\s+compressed\s+datasets\s+currently\s+not\s+supported\s+by\s+hickle\s+!!"
+    ):
+        dump(data, "test.hkl", compression='gzip')
     data2 = load("test.hkl")
 
     print(data2)


### PR DESCRIPTION
Quick fixes #140 by filtering any hdf5 kwarg related to
compression. A warning is issued that currently compression is not
supported.


Implemented along suggestion proposed in issue #140.
### Obsoleted by #138