### PR TITLE
Fix for failing tests with numpy 1.24.1

### DIFF
--- a/hickle/tests/test_hickle.py
+++ b/hickle/tests/test_hickle.py
@@ -742,7 +742,7 @@ def test_scalar_compression(test_file_name):
     (Scalars are incompressible!)
     https://github.com/telegraphic/hickle/issues/37
     """
-    data = {'a': 0, 'b': np.float(2), 'c': True}
+    data = {'a': 0, 'b': float(2), 'c': True}
 
     dump(data, test_file_name, compression='gzip')
     data2 = load(test_file_name)


### PR DESCRIPTION
numpy has removed numpy.float(), the solution is to use a regular float() instead

Debian bug report here: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1027194